### PR TITLE
feat: migrate gallery flows to provider-backed image API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ REACT_APP_FIREBASE_MEASUREMENT_ID=...
 REACT_APP_API_URL=http://localhost:3003
 ```
 
+`REACT_APP_API_URL` is the frontend's backend API boundary. Backend provider settings such as `DATABASE_PROVIDER`, `STORAGE_PROVIDER`, `AUTH_PROVIDER`, `SQLITE_PATH`, and `LOCAL_STORAGE_ROOT` belong only in the backend environment.
+
 ## Scripts
 - `yarn start`: run local dev server at `http://localhost:3000`
 - `yarn test`: run Jest/RTL tests
@@ -45,5 +47,5 @@ REACT_APP_API_URL=http://localhost:3003
 
 ## Notes
 - This repository contains the frontend application.
-- The image upload/delete API is consumed via `REACT_APP_API_URL` and is expected to run separately.
+- The gallery, upload, and delete MVP flows call the backend through `REACT_APP_API_URL`.
 - Use Yarn for dependency management (`yarn.lock` is the canonical lockfile).

--- a/docs/photogram-mvp-implementation-plan.md
+++ b/docs/photogram-mvp-implementation-plan.md
@@ -1,0 +1,1515 @@
+# Photogram Provider-Agnostic MVP Implementation Plan
+
+Status: Draft v1
+Audience: Codex, project maintainer
+Related document: `docs/photogram-provider-agnostic-system-spec.md`
+
+---
+
+## 1. Purpose
+
+This document defines the smallest safe implementation plan for moving Photogram toward a provider-agnostic architecture.
+
+The system specification defines the target architecture. This MVP plan defines the practical order of code changes needed to make the app work with local self-hosted services while preserving existing user-facing behavior.
+
+The MVP is not a full Firebase replacement. It is the first working provider-agnostic slice.
+
+---
+
+## 2. MVP Goal
+
+The MVP goal is:
+
+```text
+Photogram can run with Firebase Auth, SQLite metadata, and local filesystem image storage while the frontend remains source-agnostic and talks only to the Photogram backend API for gallery/upload/delete flows.
+```
+
+The intended MVP provider configuration is:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+This avoids rewriting authentication first. Firebase Auth may remain during the MVP, but Firestore and Firebase Storage should no longer be required for the main gallery/upload/delete flow in local mode.
+
+---
+
+## 3. MVP Non-Goals
+
+The following are intentionally outside the MVP:
+
+1. Local username/password authentication.
+2. Full account registration and password reset flows.
+3. MinIO, PostgreSQL, Redis, Docker Compose, or background workers.
+4. Public/private media optimization through Nginx `X-Accel-Redirect`.
+5. Complex pagination, albums, tagging, search, comments, or sharing.
+6. Admin dashboards.
+7. Full historical data migration from Firestore unless explicitly added later.
+8. Removing Firebase SDK usage from login/bootstrap before local auth exists.
+9. Perfect Firebase/local feature parity.
+10. A generalized plugin system that loads arbitrary provider modules from `.env`.
+
+---
+
+## 4. MVP Success Criteria
+
+The MVP is successful when:
+
+1. Backend provider selection happens once at startup through config/container code.
+2. Controllers and services do not branch on provider names.
+3. `.env` can select:
+
+    ```env
+    AUTH_PROVIDER=firebase
+    DATABASE_PROVIDER=sqlite
+    STORAGE_PROVIDER=local
+    ```
+
+4. Backend upload stores processed images on local disk.
+5. Backend upload stores image metadata in SQLite.
+6. Backend delete removes local image files and SQLite metadata.
+7. Backend gallery endpoints return normalized image DTOs.
+8. Frontend public gallery uses backend `GET /images/public`.
+9. Frontend user gallery uses backend `GET /images/me`.
+10. Frontend upload/delete flows call backend API wrappers only.
+11. Frontend gallery/upload/delete flows do not directly use Firestore or Firebase Storage.
+12. Existing compatibility endpoints still work where practical:
+
+    ```text
+    POST /resize-upload
+    POST /delete-image
+    ```
+
+13. Automated backend tests cover provider config, local storage, SQLite repository, and image service behavior.
+14. Frontend tests cover gallery rendering from backend API responses and upload/delete API calls.
+15. The backend remains safe for the Samsung NC110 low-memory deployment profile.
+
+---
+
+## 5. Final MVP Architecture
+
+```text
+React frontend
+  |
+  | Photogram API
+  v
+Express backend
+  |
+  |-- AuthProvider=firebase
+  |-- ImageRepository=sqlite
+  |-- StorageProvider=local
+  |-- ImageProcessor=sharp|jimp
+  |
+  v
+Firebase Auth + SQLite DB + local filesystem
+```
+
+The frontend should not know whether image metadata comes from Firestore or SQLite. It should not know whether image files come from Firebase Storage or local disk.
+
+---
+
+## 6. Required Environment Variables
+
+### 6.1 Backend Local MVP
+
+```env
+NODE_ENV=development
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=./data/photogram.sqlite
+LOCAL_STORAGE_ROOT=./data/images
+PUBLIC_MEDIA_BASE_URL=http://localhost:3000/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 6.2 Backend NC110 Production MVP
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+If `sharp` is unstable on the Samsung NC110, switch to:
+
+```env
+IMAGE_PROCESSOR=jimp
+```
+
+### 6.3 Frontend MVP
+
+```env
+REACT_APP_API_URL=http://localhost:3003
+```
+
+The frontend can keep Firebase Auth config during the MVP, but gallery/upload/delete should go through backend API clients. Backend provider settings such as `AUTH_PROVIDER`, `DATABASE_PROVIDER`, `STORAGE_PROVIDER`, `SQLITE_PATH`, and `LOCAL_STORAGE_ROOT` are backend-only.
+
+---
+
+## 7. Canonical MVP API Contract
+
+### 7.1 Health
+
+```text
+GET /health
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+### 7.2 Public Images
+
+```text
+GET /images/public
+```
+
+Response:
+
+```json
+{
+    "images": [
+        {
+            "id": "img_123",
+            "ownerId": "uid_123",
+            "title": "Example",
+            "description": "",
+            "imageUrl": "http://localhost:3000/media/users/uid_123/images/img_123.webp",
+            "thumbnailUrl": "http://localhost:3000/media/users/uid_123/thumbnails/img_123.webp",
+            "width": 1280,
+            "height": 720,
+            "sizeBytes": 123456,
+            "mimeType": "image/webp",
+            "isPublic": true,
+            "createdAt": "2026-06-22T00:00:00.000Z",
+            "updatedAt": "2026-06-22T00:00:00.000Z"
+        }
+    ]
+}
+```
+
+### 7.3 My Images
+
+```text
+GET /images/me
+Authorization: Bearer <firebase-id-token>
+```
+
+Response:
+
+```json
+{
+    "images": []
+}
+```
+
+### 7.4 Upload Image
+
+```text
+POST /images
+Authorization: Bearer <firebase-id-token>
+Content-Type: multipart/form-data
+```
+
+Form fields:
+
+```text
+image: File
+isPublic: true|false
+caption: optional string
+```
+
+Response:
+
+```json
+{
+    "image": {
+        "id": "img_123",
+        "ownerId": "uid_123",
+        "imageUrl": "http://localhost:3000/media/users/uid_123/images/img_123.webp",
+        "thumbnailUrl": "http://localhost:3000/media/users/uid_123/thumbnails/img_123.webp",
+        "isPublic": true,
+        "createdAt": "2026-06-22T00:00:00.000Z"
+    }
+}
+```
+
+### 7.5 Delete Image
+
+```text
+DELETE /images/:imageId
+Authorization: Bearer <firebase-id-token>
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+### 7.6 Compatibility Endpoint: Upload
+
+```text
+POST /resize-upload
+Authorization: Bearer <firebase-id-token>
+Content-Type: multipart/form-data
+```
+
+This should call the same backend service used by `POST /images`.
+
+### 7.7 Compatibility Endpoint: Delete
+
+```text
+POST /delete-image
+Authorization: Bearer <firebase-id-token>
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+    "imageId": "img_123"
+}
+```
+
+This should call the same backend service used by `DELETE /images/:imageId`.
+
+---
+
+## 8. Normalized Image DTO
+
+The backend should return this frontend-facing shape regardless of provider:
+
+```ts
+type PhotogramImage = {
+    id: string;
+    ownerId?: string;
+    title?: string;
+    description?: string;
+    imageUrl: string;
+    thumbnailUrl?: string;
+    width?: number;
+    height?: number;
+    sizeBytes?: number;
+    mimeType?: string;
+    isPublic: boolean;
+    createdAt: string;
+    updatedAt?: string;
+};
+```
+
+Provider-specific fields such as `storageKey`, `thumbnailKey`, Firebase bucket names, filesystem paths, and signed URL internals must not be required by frontend components.
+
+The database should store storage keys, not provider-specific permanent URLs.
+
+---
+
+## 9. SQLite MVP Schema
+
+Use a small SQLite schema first.
+
+```sql
+CREATE TABLE IF NOT EXISTS images (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    title TEXT,
+    description TEXT,
+    storage_key TEXT NOT NULL,
+    thumbnail_key TEXT,
+    width INTEGER,
+    height INTEGER,
+    size_bytes INTEGER,
+    mime_type TEXT,
+    is_public INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_public_created_at
+ON images (is_public, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_images_owner_created_at
+ON images (owner_id, created_at DESC);
+```
+
+MVP delete behavior:
+
+```text
+Hard delete files from local storage.
+Hard delete or soft delete DB row based on easiest compatibility with current UI.
+Preferred initial implementation: soft delete DB row using deleted_at, then exclude deleted rows from list queries.
+```
+
+---
+
+## 10. Local Storage Layout
+
+Suggested local development layout:
+
+```text
+./data/
+  photogram.sqlite
+  images/
+    users/
+      <ownerId>/
+        images/
+          <imageId>.webp
+        thumbnails/
+          <imageId>.webp
+```
+
+Suggested production layout:
+
+```text
+/var/lib/photogram/
+  photogram.sqlite
+  images/
+    users/
+      <ownerId>/
+        images/
+          <imageId>.webp
+        thumbnails/
+          <imageId>.webp
+```
+
+Storage keys should be relative paths such as:
+
+```text
+users/<ownerId>/images/<imageId>.webp
+users/<ownerId>/thumbnails/<imageId>.webp
+```
+
+The local storage provider must reject path traversal attempts such as:
+
+```text
+../secret.txt
+users/../../secret.txt
+/path/outside/root.jpg
+```
+
+---
+
+## 11. Implementation Slices
+
+Each slice should be small enough for one Codex task or one focused commit.
+
+---
+
+### Slice 0: Baseline Audit
+
+Goal: establish the current behavior before refactoring.
+
+Tasks:
+
+1. Identify current backend upload/delete routes and Firebase calls.
+2. Identify current frontend Firestore and Firebase Storage usage in gallery/upload/delete flows.
+3. Record current manual test commands.
+4. Record current env variables.
+
+Expected output:
+
+```text
+A short note in the PR or commit message listing current files touched by Firebase gallery/storage logic.
+```
+
+Acceptance checks:
+
+```bash
+# Backend
+npm test
+npm start
+
+# Frontend
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+/login works.
+/ public gallery still renders with current provider.
+/upload still submits with current provider.
+/mygallery still renders with current provider.
+```
+
+---
+
+### Slice 1: Backend Env Parsing
+
+Goal: parse and validate provider-related env values in one place.
+
+Files likely added/changed:
+
+```text
+config/env.js
+tests/env.test.js
+index.js
+```
+
+Tasks:
+
+1. Add `readEnv()`.
+2. Parse provider values:
+
+    ```text
+    AUTH_PROVIDER
+    DATABASE_PROVIDER
+    STORAGE_PROVIDER
+    ```
+
+3. Parse local provider values:
+
+    ```text
+    SQLITE_PATH
+    LOCAL_STORAGE_ROOT
+    PUBLIC_MEDIA_BASE_URL
+    ```
+
+4. Parse Firebase values:
+
+    ```text
+    FIREBASE_SERVICE_ACCOUNT_PATH
+    FIREBASE_STORAGE_BUCKET
+    FIREBASE_URL_MODE
+    FIREBASE_SIGNED_URL_EXPIRES_SECONDS
+    ```
+
+5. Parse low-memory values:
+
+    ```text
+    LOW_MEMORY_MODE
+    MAX_FILE_SIZE_MB
+    RESIZE_CONCURRENCY
+    HEAVY_RATE_LIMIT_MAX
+    ENABLE_DEBUG_ENDPOINT
+    IMAGE_PROCESSOR
+    ```
+
+6. Validate allowed provider names.
+7. Fail fast on invalid provider combinations or missing required values.
+8. Add unit tests.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/env.test.js
+```
+
+Required tests:
+
+```text
+- defaults to firebase/sqlite/local only if intentionally configured that way
+- invalid AUTH_PROVIDER fails
+- invalid DATABASE_PROVIDER fails
+- invalid STORAGE_PROVIDER fails
+- sqlite requires SQLITE_PATH
+- local storage requires LOCAL_STORAGE_ROOT
+- firebase provider requires FIREBASE_SERVICE_ACCOUNT_PATH
+- numeric values are parsed once and validated
+```
+
+---
+
+### Slice 2: Backend Provider Container
+
+Goal: centralize provider creation and dependency injection.
+
+Files likely added/changed:
+
+```text
+config/container.js
+app.js
+index.js
+tests/container.test.js
+```
+
+Tasks:
+
+1. Add provider registries:
+
+    ```js
+    const authProviders = {};
+    const imageRepositories = {};
+    const storageProviders = {};
+    ```
+
+2. Add `resolveProvider(registry, providerName, providerType)`.
+3. Add `createContainer(config)`.
+4. Update `index.js` so startup becomes:
+
+    ```js
+    const config = readEnv();
+    const container = createContainer(config);
+    const app = createApp(container);
+    ```
+
+5. Update `app.js` so it receives `container`.
+6. Add tests with fake providers to prove injection works.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/container.test.js
+npm start
+```
+
+Required tests:
+
+```text
+- resolves known provider names
+- rejects unsupported provider names
+- creates auth provider
+- creates image repository
+- creates storage provider
+- passes dependencies into image service factory
+```
+
+Important rule:
+
+```text
+No controller or service should read process.env directly for provider selection.
+```
+
+---
+
+### Slice 3: Local Storage Provider
+
+Goal: save, URL-resolve, and delete processed image files on local disk.
+
+Files likely added/changed:
+
+```text
+storage/localStorageProvider.js
+tests/localStorageProvider.test.js
+```
+
+Provider contract:
+
+```js
+function createStorageProvider(config) {
+    async function saveObject(input) {}
+    async function deleteObject(storageKey) {}
+    async function getUrl(storageKey, options) {}
+
+    return {
+        saveObject,
+        deleteObject,
+        getUrl
+    };
+}
+```
+
+Tasks:
+
+1. Create directories as needed.
+2. Save processed image files under `LOCAL_STORAGE_ROOT`.
+3. Return public URLs using `PUBLIC_MEDIA_BASE_URL`.
+4. Reject path traversal.
+5. Make delete idempotent where practical.
+6. Avoid unnecessary large buffers where current image processor allows.
+7. Add tests using temporary directories.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/localStorageProvider.test.js
+```
+
+Required tests:
+
+```text
+- saves object under root
+- returns URL based on PUBLIC_MEDIA_BASE_URL
+- deletes object
+- deleting missing object does not crash, if selected behavior is idempotent
+- rejects ../ traversal
+- rejects absolute paths outside root
+```
+
+---
+
+### Slice 4: SQLite Image Repository
+
+Goal: store and query image metadata locally.
+
+Files likely added/changed:
+
+```text
+repositories/sqliteImageRepository.js
+tests/sqliteImageRepository.test.js
+package.json
+package-lock.json
+```
+
+Tasks:
+
+1. Choose lightweight SQLite dependency.
+2. Initialize schema on repository creation or with an explicit `init()` called at startup.
+3. Implement:
+
+    ```js
+    listPublicImages(options)
+    listImagesByOwner(ownerId, options)
+    findImageById(imageId)
+    createImage(imageData)
+    markImageDeleted(imageId, ownerId)
+    deleteImageById(imageId, ownerId)
+    ```
+
+4. Exclude soft-deleted rows from list queries.
+5. Order gallery queries by newest first.
+6. Add tests using temporary SQLite DB files or in-memory DB where supported.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/sqliteImageRepository.test.js
+```
+
+Required tests:
+
+```text
+- creates schema
+- inserts image metadata
+- lists public images newest first
+- lists images by owner newest first
+- finds image by id
+- excludes deleted images
+- delete is owner-scoped
+```
+
+NC110 note:
+
+```text
+Prefer a dependency and access pattern that does not add a long-running database daemon.
+```
+
+---
+
+### Slice 5: Image Presenter / DTO Mapper
+
+Goal: convert repository records into frontend-safe `PhotogramImage` DTOs.
+
+Files likely added/changed:
+
+```text
+services/imagePresenter.js
+tests/imagePresenter.test.js
+```
+
+Tasks:
+
+1. Map database snake_case fields to frontend camelCase fields.
+2. Call `storageProvider.getUrl(storageKey)` for `imageUrl`.
+3. Call `storageProvider.getUrl(thumbnailKey)` for `thumbnailUrl` when present.
+4. Hide provider internals from frontend DTOs.
+5. Add tests with fake storage provider.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imagePresenter.test.js
+```
+
+Required tests:
+
+```text
+- maps image row to PhotogramImage DTO
+- generates imageUrl from storage provider
+- generates thumbnailUrl from storage provider
+- does not expose storageKey by default
+```
+
+---
+
+### Slice 6: Image Service
+
+Goal: centralize upload/list/delete business logic behind provider contracts.
+
+Files likely added/changed:
+
+```text
+services/imageService.js
+tests/imageService.test.js
+```
+
+Tasks:
+
+1. Implement public list flow:
+
+    ```js
+    listPublicImages(options)
+    ```
+
+2. Implement user list flow:
+
+    ```js
+    listImagesForUser(userId, options)
+    ```
+
+3. Implement upload flow:
+
+    ```js
+    createImageForUser(user, uploadInput)
+    ```
+
+4. Implement delete flow:
+
+    ```js
+    deleteImageForUser(user, imageId)
+    ```
+
+5. Ensure upload sequence is safe:
+
+    ```text
+    validate input
+    process image
+    save image file
+    save thumbnail file
+    create metadata
+    return DTO
+    ```
+
+6. Ensure delete sequence is safe:
+
+    ```text
+    load metadata
+    check ownership
+    delete image file
+    delete thumbnail file
+    mark/delete metadata
+    return ok
+    ```
+
+7. Add cleanup behavior when storage succeeds but metadata fails.
+8. Add tests using fake repository/storage/image processor.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imageService.test.js
+```
+
+Required tests:
+
+```text
+- lists public images
+- lists owner images
+- creates image metadata after storage save
+- returns normalized DTO
+- deletes image only for owner
+- rejects delete for non-owner
+- cleans up storage if metadata creation fails
+- handles missing image with clear error
+```
+
+---
+
+### Slice 7: Firebase Auth Provider for MVP
+
+Goal: keep existing login behavior but let the backend authorize authenticated routes.
+
+Files likely added/changed:
+
+```text
+auth/firebaseAuthProvider.js
+config/firebase.js
+tests/firebaseAuthProvider.test.js
+```
+
+Provider contract:
+
+```js
+function createAuthProvider(config) {
+    async function getCurrentUser(req) {}
+    async function requireUser(req) {}
+
+    return {
+        getCurrentUser,
+        requireUser
+    };
+}
+```
+
+Tasks:
+
+1. Read Firebase ID token from:
+
+    ```text
+    Authorization: Bearer <token>
+    ```
+
+2. Validate token with Firebase Admin SDK.
+3. Return normalized user shape:
+
+    ```js
+    {
+        id: decodedToken.uid,
+        email: decodedToken.email || null,
+        provider: 'firebase'
+    }
+    ```
+
+4. Return `401` through controller/middleware when auth is required and missing/invalid.
+5. Keep service account path outside the repository.
+6. Add tests with mocked Firebase Admin verification.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/firebaseAuthProvider.test.js
+```
+
+Required tests:
+
+```text
+- extracts bearer token
+- rejects missing token on requireUser
+- normalizes decoded Firebase token
+- handles Firebase verification failure
+```
+
+---
+
+### Slice 8: Backend HTTP Routes
+
+Goal: expose canonical image routes and preserve compatibility endpoints.
+
+Files likely added/changed:
+
+```text
+controllers/imageController.js
+routes/imageRoutes.js
+routes/systemRoutes.js
+app.js
+tests/imageRoutes.test.js
+```
+
+Canonical routes:
+
+```text
+GET    /images/public
+GET    /images/me
+POST   /images
+DELETE /images/:imageId
+```
+
+Compatibility routes:
+
+```text
+POST   /resize-upload
+POST   /delete-image
+```
+
+Tasks:
+
+1. Wire controllers to `container.imageService`.
+2. Use `container.authProvider` for protected routes.
+3. Keep endpoint paths lowercase and hyphenated for compatibility endpoints.
+4. Return normalized JSON responses.
+5. Add route tests with fake service/auth providers.
+6. Keep existing upload size/rate-limit middleware.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/imageRoutes.test.js
+npm test
+```
+
+Manual checks:
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/images/public
+```
+
+Upload/delete manual checks should be completed after frontend token handling is wired.
+
+---
+
+### Slice 9: Static Media Serving for Local Public Files
+
+Goal: allow local public image URLs to resolve in development and simple production deployments.
+
+Files likely added/changed:
+
+```text
+app.js
+middleware/staticMedia.js
+tests/staticMedia.test.js
+```
+
+Tasks:
+
+1. Serve `/media/*` from `LOCAL_STORAGE_ROOT` only when `STORAGE_PROVIDER=local`.
+2. Ensure path traversal is not possible.
+3. Do not expose private files if private visibility is implemented separately.
+4. Document that Nginx/Caddy static serving may replace Express static serving later.
+
+Acceptance checks:
+
+```bash
+npm test -- tests/staticMedia.test.js
+```
+
+Manual checks:
+
+```text
+Uploaded public image URL opens in browser.
+Thumbnail URL opens in browser.
+```
+
+---
+
+### Slice 10: Frontend Image API Wrapper
+
+Goal: make the frontend call the Photogram API instead of Firebase/Firestore for gallery/upload/delete.
+
+Files likely added/changed:
+
+```text
+src/api/images.ts
+src/config.ts
+src/api/images.test.ts
+```
+
+Tasks:
+
+1. Ensure `REACT_APP_API_URL` is the only backend URL source.
+2. Implement:
+
+    ```ts
+    getPublicImages()
+    getMyImages(token?: string)
+    uploadImage(input)
+    deleteImage(imageId, token?: string)
+    ```
+
+3. Normalize backend responses.
+4. Keep API functions small and testable.
+5. Keep Firebase Auth token acquisition outside the image API when practical.
+
+Acceptance checks:
+
+```bash
+yarn test src/api/images.test.ts
+```
+
+Required tests:
+
+```text
+- getPublicImages calls /images/public
+- getMyImages calls /images/me with auth header when token provided
+- uploadImage posts multipart data
+- deleteImage calls DELETE /images/:imageId
+- handles non-ok response with useful error
+```
+
+---
+
+### Slice 11: Frontend Gallery Migration
+
+Goal: public and user galleries render backend DTOs.
+
+Files likely added/changed:
+
+```text
+src/components/Gallery/*
+src/state/*
+src/api/images.ts
+```
+
+Tasks:
+
+1. Replace direct Firestore gallery reads with `getPublicImages()`.
+2. Replace direct Firestore user gallery reads with `getMyImages()`.
+3. Keep React components rendering `PhotogramImage` DTOs.
+4. Ensure loading/error/empty states still work.
+5. Add or update colocated tests.
+
+Acceptance checks:
+
+```bash
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+/ renders public images from backend API.
+/mygallery renders current user's images from backend API.
+Empty gallery state still renders correctly.
+API error state does not crash app.
+```
+
+---
+
+### Slice 12: Frontend Upload/Delete Migration
+
+Goal: upload and delete use backend image API functions only.
+
+Files likely added/changed:
+
+```text
+src/components/Upload/*
+src/components/Gallery/*
+src/state/*
+src/api/images.ts
+```
+
+Tasks:
+
+1. Change upload flow to call backend API wrapper.
+2. Change delete flow to call backend API wrapper.
+3. Ensure authenticated requests include Firebase ID token during MVP.
+4. Update Redux action creators/thunks if upload/delete logic lives there.
+5. Remove or isolate Firebase Storage calls from upload/delete flows.
+6. Add/update tests.
+
+Acceptance checks:
+
+```bash
+yarn test
+yarn build
+```
+
+Manual checks:
+
+```text
+Login works.
+Upload image works.
+Uploaded image appears in /mygallery.
+Public image appears in / when isPublic=true.
+Delete image removes it from /mygallery and backend storage.
+Delete failure shows useful UI feedback.
+```
+
+---
+
+### Slice 13: End-to-End Local MVP Validation
+
+Goal: prove the local MVP mode works end-to-end.
+
+Backend env:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+Validation commands:
+
+```bash
+# Backend
+npm test
+npm start
+
+# Frontend
+yarn test
+yarn build
+yarn start
+```
+
+Manual backend checks:
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/images/public
+```
+
+Manual browser checks:
+
+```text
+1. Open frontend.
+2. Login with Firebase Auth.
+3. Open /upload.
+4. Upload valid image.
+5. Confirm image file exists under LOCAL_STORAGE_ROOT.
+6. Confirm SQLite row exists.
+7. Open /mygallery.
+8. Confirm uploaded image appears.
+9. Open /.
+10. Confirm public image appears if public.
+11. Delete image.
+12. Confirm image is removed from UI.
+13. Confirm file is deleted or no longer reachable.
+14. Confirm SQLite row is deleted or soft-deleted.
+```
+
+Upload safety checks:
+
+```text
+- valid image
+- non-image file
+- empty payload
+- oversize payload based on MAX_FILE_SIZE_MB
+- unauthenticated upload
+- unauthenticated delete
+```
+
+---
+
+### Slice 14: NC110 Deployment Check
+
+Goal: verify the MVP mode on the target low-resource server.
+
+Tasks:
+
+1. Create production directories:
+
+    ```bash
+    sudo mkdir -p /var/lib/photogram/images
+    sudo mkdir -p /var/backups/photogram
+    ```
+
+2. Set ownership to the backend process user.
+3. Deploy backend `.env` outside source control.
+4. Start or reload PM2 process.
+5. Validate logs and memory usage.
+6. Test upload/delete with small image files first.
+7. Validate `sharp`; switch to `jimp` if needed.
+8. Document PM2 command and current env assumptions.
+
+Validation commands:
+
+```bash
+pm2 status
+pm2 logs photogram-backend
+curl http://localhost:3000/health
+```
+
+Operational checks:
+
+```text
+- memory does not grow unexpectedly across repeated uploads
+- upload concurrency remains low
+- oversized files are rejected early
+- debug endpoint remains disabled in production
+- SQLite file and image directory are included in backup plan
+```
+
+---
+
+## 12. Recommended Commit Order
+
+Use small commits with Conventional Commit-style prefixes.
+
+```text
+feat: add provider env parsing
+feat: add backend provider container
+feat: add local storage provider
+feat: add sqlite image repository
+feat: add image DTO presenter
+feat: add provider-backed image service
+feat: add firebase auth provider
+feat: add canonical image routes
+feat: serve local media files
+feat: migrate frontend image API client
+feat: migrate gallery reads to backend API
+feat: migrate upload delete flows to backend API
+fix: validate local MVP mode end to end
+```
+
+Prefer one slice per PR or one small group of tightly related slices.
+
+---
+
+## 13. Codex Task Prompts
+
+Use these prompts one at a time.
+
+### Prompt 1
+
+```text
+Read docs/photogram-provider-agnostic-system-spec.md and docs/photogram-mvp-implementation-plan.md. Implement Slice 1 only: backend env parsing and validation. Keep CommonJS style, 4-space indentation, semicolons, and add node:test coverage under tests/env.test.js. Do not change controllers or route behavior.
+```
+
+### Prompt 2
+
+```text
+Implement Slice 2 only: backend provider container. Add config/container.js with safe provider registries and tests. Update index.js/app.js only as needed for dependency injection. Do not implement SQLite or local storage yet; use existing providers or small placeholders where necessary.
+```
+
+### Prompt 3
+
+```text
+Implement Slice 3 only: local storage provider. Add storage/localStorageProvider.js and tests using temporary directories. It must reject path traversal, save files under LOCAL_STORAGE_ROOT, delete objects, and generate URLs from PUBLIC_MEDIA_BASE_URL.
+```
+
+### Prompt 4
+
+```text
+Implement Slice 4 only: SQLite image repository. Add schema initialization, list/create/find/delete methods, and node:test coverage. Keep dependencies lightweight for the Samsung NC110.
+```
+
+### Prompt 5
+
+```text
+Implement Slices 5 and 6 only: image presenter and image service. Use injected repository/storage/auth/image processor dependencies. Add tests with fake providers. Do not make controllers branch on provider names.
+```
+
+### Prompt 6
+
+```text
+Implement Slices 7 and 8 only: Firebase Auth provider and canonical image routes. Preserve compatibility endpoints /resize-upload and /delete-image by routing them through the same image service. Add route/auth tests.
+```
+
+### Prompt 7
+
+```text
+Implement Slice 10 only: frontend image API wrapper. Use REACT_APP_API_URL, TypeScript types, and tests. Do not change gallery components yet.
+```
+
+### Prompt 8
+
+```text
+Implement Slice 11 only: migrate public and user gallery reads to the backend image API. Remove or isolate direct Firestore reads from gallery flows. Add/update React Testing Library tests.
+```
+
+### Prompt 9
+
+```text
+Implement Slice 12 only: migrate upload and delete flows to backend API wrappers. Authenticated requests should use the current Firebase ID token during the MVP. Add/update tests and keep UI behavior unchanged.
+```
+
+### Prompt 10
+
+```text
+Run the MVP validation checklist from docs/photogram-mvp-implementation-plan.md. Fix only issues directly required for AUTH_PROVIDER=firebase, DATABASE_PROVIDER=sqlite, STORAGE_PROVIDER=local mode to pass upload, list, and delete.
+```
+
+---
+
+## 14. Backend Testing Matrix
+
+| Area | Required command | Required coverage |
+|---|---|---|
+| Env parsing | `npm test -- tests/env.test.js` | provider names, required env, numeric values |
+| Container | `npm test -- tests/container.test.js` | safe registry, provider injection |
+| Local storage | `npm test -- tests/localStorageProvider.test.js` | save, delete, URL, traversal rejection |
+| SQLite repository | `npm test -- tests/sqliteImageRepository.test.js` | schema, create, list, find, delete |
+| DTO presenter | `npm test -- tests/imagePresenter.test.js` | URL generation, provider internals hidden |
+| Image service | `npm test -- tests/imageService.test.js` | upload/list/delete, cleanup, ownership |
+| Auth provider | `npm test -- tests/firebaseAuthProvider.test.js` | token extraction, normalized user, auth failure |
+| Routes | `npm test -- tests/imageRoutes.test.js` | canonical and compatibility endpoints |
+| Full backend | `npm test` | all backend tests |
+
+---
+
+## 15. Frontend Testing Matrix
+
+| Area | Required command | Required coverage |
+|---|---|---|
+| Image API | `yarn test src/api/images.test.ts` | calls backend endpoints, handles errors |
+| Public gallery | `yarn test` | renders backend image DTOs |
+| User gallery | `yarn test` | authenticated gallery renders backend DTOs |
+| Upload | `yarn test` | calls backend upload wrapper |
+| Delete | `yarn test` | calls backend delete wrapper |
+| Production build | `yarn build` | CRA build succeeds |
+
+---
+
+## 16. Manual Validation Checklist
+
+### Backend
+
+```text
+[ ] /health returns ok.
+[ ] /images/public returns JSON array.
+[ ] /images/me rejects unauthenticated request.
+[ ] /images/me accepts valid Firebase token.
+[ ] POST /images rejects unauthenticated request.
+[ ] POST /images rejects non-image file.
+[ ] POST /images rejects empty payload.
+[ ] POST /images rejects oversize payload.
+[ ] POST /images accepts valid image.
+[ ] POST /resize-upload compatibility endpoint still works.
+[ ] DELETE /images/:imageId deletes owned image.
+[ ] DELETE /images/:imageId rejects non-owner.
+[ ] POST /delete-image compatibility endpoint still works.
+[ ] Uploaded file exists under LOCAL_STORAGE_ROOT.
+[ ] SQLite metadata row is created.
+[ ] Deleted file is removed or no longer reachable.
+[ ] SQLite metadata is deleted or soft-deleted.
+```
+
+### Frontend
+
+```text
+[ ] / renders public gallery from backend API.
+[ ] /login still works with Firebase Auth.
+[ ] /upload remains protected.
+[ ] /upload uploads through backend API.
+[ ] /mygallery remains protected.
+[ ] /mygallery renders current user's backend images.
+[ ] Delete removes image from UI and backend.
+[ ] Loading state still works.
+[ ] Empty state still works.
+[ ] API error state does not crash the app.
+```
+
+### NC110
+
+```text
+[ ] PM2 process starts.
+[ ] pm2 status is healthy.
+[ ] pm2 logs photogram-backend shows no startup config errors.
+[ ] Upload memory usage is acceptable.
+[ ] RESIZE_CONCURRENCY=1 is respected.
+[ ] MAX_FILE_SIZE_MB=5 is respected.
+[ ] ENABLE_DEBUG_ENDPOINT=false in production.
+[ ] SQLite path is writable.
+[ ] Local image directory is writable.
+[ ] Backup path exists or is documented.
+```
+
+---
+
+## 17. Risk Register
+
+### Risk: Frontend still depends on Firestore object shapes
+
+Mitigation:
+
+```text
+Create and use the normalized PhotogramImage DTO before changing many components.
+```
+
+### Risk: Local files are saved outside storage root
+
+Mitigation:
+
+```text
+Path traversal tests are required before wiring local storage into upload routes.
+```
+
+### Risk: Upload stores files but metadata insert fails
+
+Mitigation:
+
+```text
+Image service must clean up saved files if metadata creation fails.
+```
+
+### Risk: Delete removes metadata but not files
+
+Mitigation:
+
+```text
+Delete service should load metadata first, delete files, then mark/delete metadata.
+```
+
+### Risk: SQLite dependency is too heavy or incompatible
+
+Mitigation:
+
+```text
+Choose dependency carefully, test on the Samsung NC110, and keep fallback notes.
+```
+
+### Risk: Sharp is unstable on Atom-class CPU
+
+Mitigation:
+
+```text
+Keep IMAGE_PROCESSOR=sharp|jimp and validate on the target machine.
+```
+
+### Risk: Firebase Auth token handling becomes scattered
+
+Mitigation:
+
+```text
+Keep Firebase token verification inside AuthProvider only. Frontend only supplies token to API wrapper.
+```
+
+---
+
+## 18. Definition of Done for MVP
+
+The MVP is done when all of the following are true:
+
+```text
+[ ] Backend starts with AUTH_PROVIDER=firebase, DATABASE_PROVIDER=sqlite, STORAGE_PROVIDER=local.
+[ ] Provider selection is centralized in config/container code.
+[ ] Controllers and services do not branch on Firebase/sqlite/local provider names.
+[ ] Upload saves image files to LOCAL_STORAGE_ROOT.
+[ ] Upload writes metadata to SQLite.
+[ ] Public gallery reads from backend /images/public.
+[ ] User gallery reads from backend /images/me.
+[ ] Delete removes or soft-deletes both storage and metadata.
+[ ] Frontend gallery/upload/delete code does not directly use Firestore or Firebase Storage.
+[ ] Compatibility endpoints /resize-upload and /delete-image still work or are documented if intentionally replaced.
+[ ] Backend npm test passes.
+[ ] Frontend yarn test passes.
+[ ] Frontend yarn build passes.
+[ ] Manual upload/list/delete test passes locally.
+[ ] NC110 PM2 smoke test passes.
+```
+
+---
+
+## 19. Suggested Next Document After MVP
+
+After this MVP is complete, create:
+
+```text
+docs/local-auth-implementation-plan.md
+```
+
+That document should cover:
+
+```text
+AUTH_PROVIDER=local
+password hashing
+HTTP-only cookies
+session table
+CSRF considerations
+login rate limits
+frontend login/bootstrap migration
+Firebase Auth removal or optional mode
+```
+
+Local auth should not block this MVP.

--- a/docs/photogram-provider-agnostic-system-spec.md
+++ b/docs/photogram-provider-agnostic-system-spec.md
@@ -1,0 +1,1511 @@
+# Photogram Provider-Agnostic System Specification
+
+Status: Draft v1
+Audience: Codex, project maintainers, future contributors
+Primary goal: Make Photogram work the same way regardless of whether data and files come from Firebase or self-hosted services.
+
+---
+
+## 1. Purpose
+
+Photogram started as a Firebase-backed personal photo gallery. Firebase solved authentication, metadata storage, and image storage quickly, but it should no longer be treated as the only foundation of the app.
+
+This specification defines a provider-agnostic architecture where:
+
+- The React frontend talks to a stable Photogram API.
+- The Express backend owns all provider selection and heavy operations.
+- `.env` decides which providers are active.
+- Backend config validates provider choices.
+- Backend composition creates concrete provider instances.
+- Controllers and services receive already-created dependencies.
+- Firebase remains available as an optional provider, not the default assumption.
+
+The intended default deployment is self-hosted on the Samsung NC110 Ubuntu Server using lightweight local services.
+
+---
+
+## 2. Current Project Context
+
+### Frontend
+
+The frontend is a React 17 + TypeScript CRA app in `src/`.
+
+Relevant conventions:
+
+- Components live under `src/components/`.
+- Redux state lives under `src/state/`.
+- API clients live under `src/api/`.
+- Configuration comes from `REACT_APP_*` variables.
+- Tests are colocated as `*.test.tsx` files.
+- The project is Yarn-first.
+
+Current major flows:
+
+- Public gallery: `/`
+- Login: `/login`
+- Protected upload page: `/upload`
+- Protected user gallery: `/mygallery`
+
+Important current files:
+
+- `src/components/App/App.tsx`
+- `src/components/App/AppInitializer.tsx`
+- `src/components/App/ProtectedRoute.tsx`
+- `src/api/images.ts`
+- `src/firebase.configuration.ts`
+
+### Backend
+
+The backend is a separate Express/Firebase service.
+
+Relevant conventions:
+
+- CommonJS JavaScript.
+- 4-space indentation.
+- Semicolons.
+- Single quotes.
+- Lowercase hyphenated endpoint paths.
+- `index.js` should stay a thin startup entrypoint.
+- `app.js` should compose middleware, routes, and error handlers.
+- `config/` owns environment parsing and provider initialization.
+- `controllers/` own request handlers.
+- `routes/` own route wiring.
+- `middleware/` owns upload, CORS, size guards, rate limits, and error handling.
+- `utils/` owns shared helpers such as logging and semaphores.
+- Tests live under `tests/` and use `node:test` plus `node:assert/strict`.
+
+Deployment target:
+
+- Samsung Netbook NC110
+- Ubuntu Server 24.04.3 LTS
+- Intel Atom CPU
+- 2GB RAM
+- 250GB SSD
+- PM2-managed process
+
+Operational constraints:
+
+- Prefer low-memory and low-CPU changes.
+- Stream I/O where practical.
+- Avoid loading large buffers unnecessarily.
+- Keep dependencies lightweight.
+- Validate `sharp` versus `jimp` on target hardware.
+- Keep upload concurrency low.
+
+---
+
+## 3. Goals
+
+1. Make Firebase optional.
+2. Make local self-hosted services the default direction.
+3. Keep the frontend source-agnostic.
+4. Move gallery metadata access behind backend APIs.
+5. Move image storage, deletion, URL resolution, resizing, compression, and safety controls behind backend providers.
+6. Allow provider switching through `.env` without changing controllers, services, or frontend feature code.
+7. Preserve the current user-facing functionality.
+8. Preserve compatibility with existing endpoints during migration where practical.
+9. Keep the system small enough to run reliably on the NC110.
+
+---
+
+## 4. Non-Goals
+
+1. Do not build a generic Firebase clone.
+2. Do not introduce Docker, MinIO, PostgreSQL, Redis, or background workers as first-step requirements.
+3. Do not rewrite the entire frontend at once.
+4. Do not remove Firebase Auth immediately unless local auth is explicitly implemented in that phase.
+5. Do not expose local filesystem layout or provider internals to the frontend.
+6. Do not make `.env` able to load arbitrary JavaScript modules.
+7. Do not store provider-specific URLs as the permanent source of truth.
+
+---
+
+## 5. Core Architecture Rule
+
+The architectural rule is:
+
+```text
+.env chooses providers.
+config validates providers.
+container creates providers.
+services use provider interfaces.
+controllers call services.
+routes wire controllers.
+frontend calls the Photogram API.
+```
+
+The frontend must not care whether Photogram uses:
+
+- Firebase Auth
+- local auth
+- Firestore
+- SQLite
+- Firebase Storage
+- local filesystem storage
+- a future provider
+
+Controllers and services must not branch on provider names.
+
+Forbidden outside `config/` or composition code:
+
+```js
+if (process.env.DATABASE_PROVIDER === 'firebase') {
+    // ...
+}
+```
+
+Forbidden everywhere:
+
+```js
+require(process.env.IMAGE_REPOSITORY_MODULE);
+```
+
+Allowed pattern:
+
+```js
+const imageRepository = resolveProvider(
+    imageRepositories,
+    config.databaseProvider,
+    'database'
+).createImageRepository(config);
+```
+
+The selected implementation should be resolved once at startup and then injected.
+
+---
+
+## 6. Target Runtime Architecture
+
+```text
+React frontend
+  |
+  | Stable Photogram HTTP API
+  v
+Express backend
+  |
+  |-- AuthProvider
+  |-- ImageRepository
+  |-- StorageProvider
+  |-- ImageProcessor
+  |
+  v
+Provider implementations
+  |
+  |-- Firebase Auth, Firestore, Firebase Storage
+  |-- local auth, SQLite, local filesystem
+  |-- future providers
+```
+
+The backend owns:
+
+- authentication verification
+- authorization decisions
+- image upload validation
+- image resize/compression
+- thumbnail generation
+- storage writes/deletes
+- metadata writes/deletes
+- provider-specific URL generation
+- rate limits
+- file-size limits
+- low-memory safeguards
+
+The frontend owns:
+
+- UI composition
+- route rendering
+- form state
+- gallery rendering
+- upload user experience
+- Redux state
+- calls to `src/api/*`
+
+---
+
+## 7. Provider Types
+
+Photogram has three major provider categories.
+
+### 7.1 AuthProvider
+
+Responsible for identifying the current user and enforcing authenticated routes.
+
+Initial provider options:
+
+- `firebase`
+- `local` later
+
+### 7.2 ImageRepository
+
+Responsible for image metadata.
+
+Initial provider options:
+
+- `firebase`
+- `sqlite`
+
+### 7.3 StorageProvider
+
+Responsible for image files and URL resolution.
+
+Initial provider options:
+
+- `firebase`
+- `local`
+
+---
+
+## 8. Default Provider Direction
+
+The desired long-term default is:
+
+```env
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+The practical migration default may initially be:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+Firebase-compatible mode remains:
+
+```env
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=firebase
+STORAGE_PROVIDER=firebase
+```
+
+---
+
+## 9. Provider Configuration
+
+### 9.1 Local/SQLite Default
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 9.2 Transitional Mode: Firebase Auth + Local Data/Storage
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+
+SQLITE_PATH=/var/lib/photogram/photogram.sqlite
+LOCAL_STORAGE_ROOT=/var/lib/photogram/images
+PUBLIC_MEDIA_BASE_URL=https://photos.example.com/media
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+### 9.3 Firebase Mode
+
+```env
+NODE_ENV=production
+PORT=3000
+
+AUTH_PROVIDER=firebase
+DATABASE_PROVIDER=firebase
+STORAGE_PROVIDER=firebase
+
+FIREBASE_SERVICE_ACCOUNT_PATH=/secure/photogram/firebase-service-account.json
+FIREBASE_STORAGE_BUCKET=your-bucket.appspot.com
+FIREBASE_URL_MODE=signed
+FIREBASE_SIGNED_URL_EXPIRES_SECONDS=300
+
+LOW_MEMORY_MODE=true
+MAX_FILE_SIZE_MB=5
+RESIZE_CONCURRENCY=1
+HEAVY_RATE_LIMIT_MAX=8
+ENABLE_DEBUG_ENDPOINT=false
+IMAGE_PROCESSOR=sharp
+```
+
+---
+
+## 10. Configuration Validation Rules
+
+`config/env.js` should parse and normalize all env values.
+
+`config/container.js` or equivalent composition code should validate provider combinations.
+
+Required validation:
+
+1. `AUTH_PROVIDER` must be one of the supported auth provider keys.
+2. `DATABASE_PROVIDER` must be one of the supported repository provider keys.
+3. `STORAGE_PROVIDER` must be one of the supported storage provider keys.
+4. `DATABASE_PROVIDER=sqlite` requires `SQLITE_PATH`.
+5. `STORAGE_PROVIDER=local` requires `LOCAL_STORAGE_ROOT`.
+6. `STORAGE_PROVIDER=local` requires either `PUBLIC_MEDIA_BASE_URL` for public media URLs or a backend media route.
+7. Any Firebase provider requires `FIREBASE_SERVICE_ACCOUNT_PATH`.
+8. `STORAGE_PROVIDER=firebase` requires `FIREBASE_STORAGE_BUCKET`.
+9. `FIREBASE_URL_MODE` must be `public` or `signed`.
+10. Numeric env values must be parsed once and validated as safe integers.
+11. Provider names must not be used as raw module paths.
+
+Invalid config should fail fast during startup.
+
+---
+
+## 11. Backend Composition Pattern
+
+### 11.1 Startup
+
+`index.js` remains thin:
+
+```js
+require('dotenv').config();
+
+const { readEnv } = require('./config/env');
+const { createContainer } = require('./config/container');
+const createApp = require('./app');
+
+const config = readEnv();
+const container = createContainer(config);
+const app = createApp(container);
+
+app.listen(config.port, () => {
+    console.log(`Photogram backend listening on port ${config.port}`);
+});
+```
+
+### 11.2 App Composition
+
+`app.js` receives dependencies:
+
+```js
+const express = require('express');
+const createImageRoutes = require('./routes/imageRoutes');
+const createAuthRoutes = require('./routes/authRoutes');
+const createSystemRoutes = require('./routes/systemRoutes');
+
+function createApp(container) {
+    const app = express();
+
+    app.use('/health', createSystemRoutes(container));
+    app.use('/auth', createAuthRoutes(container));
+    app.use('/images', createImageRoutes(container));
+
+    return app;
+}
+
+module.exports = createApp;
+```
+
+### 11.3 Container
+
+Provider resolution belongs in one composition layer:
+
+```js
+const sqliteImageRepository = require('../repositories/sqliteImageRepository');
+const firebaseImageRepository = require('../repositories/firebaseImageRepository');
+const localStorageProvider = require('../storage/localStorageProvider');
+const firebaseStorageProvider = require('../storage/firebaseStorageProvider');
+const localAuthProvider = require('../auth/localAuthProvider');
+const firebaseAuthProvider = require('../auth/firebaseAuthProvider');
+const imageService = require('../services/imageService');
+
+const imageRepositories = {
+    sqlite: sqliteImageRepository,
+    firebase: firebaseImageRepository
+};
+
+const storageProviders = {
+    local: localStorageProvider,
+    firebase: firebaseStorageProvider
+};
+
+const authProviders = {
+    local: localAuthProvider,
+    firebase: firebaseAuthProvider
+};
+
+function resolveProvider(registry, providerName, providerType) {
+    const provider = registry[providerName];
+
+    if (!provider) {
+        throw new Error(`Unsupported ${providerType} provider: ${providerName}`);
+    }
+
+    return provider;
+}
+
+function createContainer(config) {
+    const imageRepository = resolveProvider(
+        imageRepositories,
+        config.databaseProvider,
+        'database'
+    ).createImageRepository(config);
+
+    const storageProvider = resolveProvider(
+        storageProviders,
+        config.storageProvider,
+        'storage'
+    ).createStorageProvider(config);
+
+    const authProvider = resolveProvider(
+        authProviders,
+        config.authProvider,
+        'auth'
+    ).createAuthProvider(config);
+
+    const images = imageService.createImageService({
+        imageRepository,
+        storageProvider,
+        authProvider,
+        config
+    });
+
+    return {
+        config,
+        authProvider,
+        imageRepository,
+        storageProvider,
+        imageService: images
+    };
+}
+
+module.exports = {
+    createContainer
+};
+```
+
+The exact file names can change, but the rule should not: provider choice is resolved once and injected.
+
+---
+
+## 12. Provider Contracts
+
+Provider contracts should be small and explicit.
+
+### 12.1 ImageRepository Contract
+
+```js
+function createImageRepository(config) {
+    async function listPublicImages(options) {}
+    async function listImagesByOwner(ownerId, options) {}
+    async function findImageById(imageId) {}
+    async function createImage(imageRecord) {}
+    async function updateImage(imageId, updates) {}
+    async function deleteImageById(imageId, ownerId) {}
+
+    return {
+        listPublicImages,
+        listImagesByOwner,
+        findImageById,
+        createImage,
+        updateImage,
+        deleteImageById
+    };
+}
+```
+
+Repository methods return internal image records, not frontend DTOs.
+
+### 12.2 StorageProvider Contract
+
+```js
+function createStorageProvider(config) {
+    async function saveObject(input) {}
+    async function deleteObject(storageKey) {}
+    async function getUrl(storageKey, options) {}
+    async function exists(storageKey) {}
+
+    return {
+        saveObject,
+        deleteObject,
+        getUrl,
+        exists
+    };
+}
+```
+
+`saveObject(input)` should accept a normalized object such as:
+
+```js
+{
+    storageKey: 'users/user_123/images/img_abc.webp',
+    buffer,
+    readableStream,
+    contentType: 'image/webp',
+    sizeBytes: 12345
+}
+```
+
+The implementation may accept either `buffer` or `readableStream`, but it should prefer streaming where practical.
+
+### 12.3 AuthProvider Contract
+
+```js
+function createAuthProvider(config) {
+    async function getCurrentUser(req) {}
+    async function requireUser(req) {}
+    async function login(credentials, res) {}
+    async function logout(req, res) {}
+
+    return {
+        getCurrentUser,
+        requireUser,
+        login,
+        logout
+    };
+}
+```
+
+For Firebase Auth, `login` may be unsupported by the backend during the transition because the frontend still signs in with Firebase. In that case, the provider should implement `getCurrentUser` and `requireUser` by validating an ID token sent by the frontend.
+
+For local auth, `login` and `logout` should use secure HTTP-only cookies.
+
+---
+
+## 13. Internal Image Record
+
+The backend database should store provider-neutral metadata.
+
+Internal record shape:
+
+```js
+{
+    id: 'img_abc',
+    ownerId: 'user_123',
+    title: 'Optional title',
+    description: 'Optional description',
+    storageKey: 'users/user_123/images/img_abc.webp',
+    thumbnailKey: 'users/user_123/thumbnails/img_abc.webp',
+    originalStorageKey: 'users/user_123/originals/img_abc.jpg',
+    mimeType: 'image/webp',
+    originalMimeType: 'image/jpeg',
+    width: 1600,
+    height: 1200,
+    thumbnailWidth: 400,
+    thumbnailHeight: 300,
+    sizeBytes: 234567,
+    originalSizeBytes: 3456789,
+    isPublic: true,
+    createdAt: '2026-06-22T12:00:00.000Z',
+    updatedAt: '2026-06-22T12:00:00.000Z',
+    deletedAt: null
+}
+```
+
+Important rule:
+
+```text
+Database stores storage keys.
+Backend generates URLs.
+Frontend receives URLs.
+```
+
+Do not treat Firebase Storage URLs, signed URLs, or local `/media/*` URLs as the permanent database source of truth.
+
+---
+
+## 14. Frontend Image DTO
+
+The frontend should receive a normalized provider-neutral DTO.
+
+```ts
+export type PhotogramImage = {
+    id: string;
+    ownerId?: string;
+    title?: string;
+    description?: string;
+    imageUrl: string;
+    thumbnailUrl?: string;
+    width?: number;
+    height?: number;
+    sizeBytes?: number;
+    mimeType?: string;
+    isPublic: boolean;
+    createdAt: string;
+    updatedAt?: string;
+};
+```
+
+Do not expose `storageKey` or `thumbnailKey` to the frontend unless there is a specific administrative/debug reason.
+
+The DTO should be created by a backend presenter/mapper, for example:
+
+```js
+async function toImageDto(imageRecord, storageProvider) {
+    return {
+        id: imageRecord.id,
+        ownerId: imageRecord.ownerId,
+        title: imageRecord.title,
+        description: imageRecord.description,
+        imageUrl: await storageProvider.getUrl(imageRecord.storageKey, {
+            visibility: imageRecord.isPublic ? 'public' : 'private'
+        }),
+        thumbnailUrl: imageRecord.thumbnailKey
+            ? await storageProvider.getUrl(imageRecord.thumbnailKey, {
+                visibility: imageRecord.isPublic ? 'public' : 'private'
+            })
+            : undefined,
+        width: imageRecord.width,
+        height: imageRecord.height,
+        sizeBytes: imageRecord.sizeBytes,
+        mimeType: imageRecord.mimeType,
+        isPublic: imageRecord.isPublic,
+        createdAt: imageRecord.createdAt,
+        updatedAt: imageRecord.updatedAt
+    };
+}
+```
+
+---
+
+## 15. Canonical Backend API
+
+Canonical endpoints should be provider-neutral.
+
+```text
+GET    /health
+
+GET    /auth/me
+POST   /auth/login
+POST   /auth/logout
+
+GET    /images/public
+GET    /images/me
+POST   /images
+DELETE /images/:imageId
+GET    /images/:imageId/file
+GET    /images/:imageId/thumbnail
+```
+
+### 15.1 Compatibility Endpoints
+
+Preserve current endpoints during migration where practical:
+
+```text
+POST   /resize-upload
+POST   /delete-image
+```
+
+These can internally call the same service methods as the canonical routes.
+
+Existing test/manual validation targets should remain valid during migration:
+
+```text
+GET/POST as applicable:
+/health
+/resize
+/upload
+/resize-upload
+/delete-image
+```
+
+---
+
+## 16. API Response Shapes
+
+### 16.1 List Public Images
+
+Request:
+
+```text
+GET /images/public
+```
+
+Response:
+
+```json
+{
+    "images": [
+        {
+            "id": "img_abc",
+            "ownerId": "user_123",
+            "title": "Photo title",
+            "description": "Photo description",
+            "imageUrl": "https://photos.example.com/media/users/user_123/images/img_abc.webp",
+            "thumbnailUrl": "https://photos.example.com/media/users/user_123/thumbnails/img_abc.webp",
+            "width": 1600,
+            "height": 1200,
+            "sizeBytes": 234567,
+            "mimeType": "image/webp",
+            "isPublic": true,
+            "createdAt": "2026-06-22T12:00:00.000Z",
+            "updatedAt": "2026-06-22T12:00:00.000Z"
+        }
+    ]
+}
+```
+
+### 16.2 List Current User Images
+
+Request:
+
+```text
+GET /images/me
+```
+
+Response:
+
+```json
+{
+    "images": []
+}
+```
+
+### 16.3 Upload Image
+
+Request:
+
+```text
+POST /images
+Content-Type: multipart/form-data
+```
+
+Fields:
+
+```text
+image: file
+isPublic: true|false
+ title: optional string
+ description: optional string
+```
+
+Response:
+
+```json
+{
+    "image": {
+        "id": "img_abc",
+        "ownerId": "user_123",
+        "title": "Photo title",
+        "description": "Photo description",
+        "imageUrl": "https://photos.example.com/media/users/user_123/images/img_abc.webp",
+        "thumbnailUrl": "https://photos.example.com/media/users/user_123/thumbnails/img_abc.webp",
+        "width": 1600,
+        "height": 1200,
+        "sizeBytes": 234567,
+        "mimeType": "image/webp",
+        "isPublic": true,
+        "createdAt": "2026-06-22T12:00:00.000Z",
+        "updatedAt": "2026-06-22T12:00:00.000Z"
+    }
+}
+```
+
+### 16.4 Delete Image
+
+Request:
+
+```text
+DELETE /images/img_abc
+```
+
+Response:
+
+```json
+{
+    "ok": true
+}
+```
+
+---
+
+## 17. Upload Flow
+
+The upload flow is owned by the backend.
+
+```text
+1. Route receives multipart upload.
+2. Middleware applies size limits and rate limits.
+3. AuthProvider identifies the current user.
+4. Controller calls imageService.uploadImage().
+5. Service validates file presence, MIME type, and size.
+6. Service calls image processor to resize/compress.
+7. Service creates storage keys.
+8. StorageProvider saves processed image.
+9. StorageProvider saves thumbnail.
+10. ImageRepository saves metadata.
+11. Service maps internal record to frontend DTO.
+12. Controller returns JSON.
+```
+
+Required safeguards:
+
+- Reject empty payloads.
+- Reject non-image files.
+- Reject oversized payloads based on `MAX_FILE_SIZE_MB`.
+- Apply upload/heavy endpoint rate limiting.
+- Limit resize concurrency using `RESIZE_CONCURRENCY`.
+- Avoid path traversal in generated storage keys.
+- Clean up partially written files if repository save fails.
+- Clean up repository record if storage save fails after partial metadata creation.
+
+---
+
+## 18. Delete Flow
+
+The delete flow is owned by the backend.
+
+```text
+1. AuthProvider identifies the current user.
+2. Controller calls imageService.deleteImage(imageId, user).
+3. Service loads image metadata.
+4. Service confirms ownership or authorization.
+5. Service deletes image and thumbnail from StorageProvider.
+6. Service deletes or soft-deletes metadata from ImageRepository.
+7. Controller returns `{ ok: true }`.
+```
+
+Default behavior should be hard delete for personal deployments unless soft delete is intentionally added.
+
+If soft delete is used, set `deletedAt` and exclude deleted rows/documents from normal list queries.
+
+Delete must be idempotent where practical. Deleting an already-missing storage object should not leave the system broken.
+
+---
+
+## 19. Local Storage Provider
+
+The local storage provider should write files under:
+
+```text
+/var/lib/photogram/images
+```
+
+Suggested layout:
+
+```text
+/var/lib/photogram/images/
+  users/
+    <ownerId>/
+      originals/
+      images/
+      thumbnails/
+  public/
+```
+
+Recommended storage keys:
+
+```text
+users/<ownerId>/images/<imageId>.webp
+users/<ownerId>/thumbnails/<imageId>.webp
+users/<ownerId>/originals/<imageId>.<ext>
+```
+
+Rules:
+
+1. Storage keys are logical keys, not arbitrary user-supplied paths.
+2. Never concatenate unchecked user input into filesystem paths.
+3. Resolve paths and verify they remain inside `LOCAL_STORAGE_ROOT`.
+4. Use atomic writes where practical.
+5. Delete derived files on failed upload.
+6. Use restrictive filesystem permissions.
+7. Do not serve private files directly from a public static route.
+
+### 19.1 Public File Serving
+
+For public images, either:
+
+1. Serve `/media/*` through Nginx/Caddy from `LOCAL_STORAGE_ROOT`; or
+2. Serve files through Express if traffic is very low.
+
+For the NC110, static serving through Nginx/Caddy is preferred for public images.
+
+### 19.2 Private File Serving
+
+Private user gallery files should not be exposed as direct public files.
+
+Acceptable options:
+
+1. Backend checks auth and streams the file.
+2. Backend checks auth and delegates with `X-Accel-Redirect` to Nginx.
+3. Backend returns short-lived signed local URLs if implemented later.
+
+Start simple: backend-authenticated streaming is acceptable for a personal deployment.
+
+---
+
+## 20. SQLite Image Repository
+
+SQLite is the preferred first local database because it is lightweight and simple to back up.
+
+Suggested table:
+
+```sql
+CREATE TABLE IF NOT EXISTS images (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    title TEXT,
+    description TEXT,
+    storage_key TEXT NOT NULL,
+    thumbnail_key TEXT,
+    original_storage_key TEXT,
+    mime_type TEXT,
+    original_mime_type TEXT,
+    width INTEGER,
+    height INTEGER,
+    thumbnail_width INTEGER,
+    thumbnail_height INTEGER,
+    size_bytes INTEGER,
+    original_size_bytes INTEGER,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_public_created_at
+ON images (is_public, created_at DESC)
+WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_images_owner_created_at
+ON images (owner_id, created_at DESC)
+WHERE deleted_at IS NULL;
+```
+
+Potential future local-auth tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+SQLite implementation rules:
+
+- Initialize schema at startup or through an explicit migration command.
+- Use parameterized queries.
+- Keep queries simple.
+- Do not add an ORM unless there is a clear benefit.
+- Enable WAL mode if it works reliably on the deployment filesystem.
+- Back up the SQLite file together with the image folder.
+
+---
+
+## 21. Firebase Providers
+
+Firebase provider implementations should remain available but isolated.
+
+### 21.1 Firebase Auth Provider
+
+Responsibilities:
+
+- Validate Firebase ID tokens.
+- Return a normalized user object.
+
+Normalized user shape:
+
+```js
+{
+    id: 'firebase-uid',
+    email: 'person@example.com',
+    displayName: 'Optional Name',
+    provider: 'firebase'
+}
+```
+
+### 21.2 Firebase Image Repository
+
+Responsibilities:
+
+- Read/write image metadata from Firestore.
+- Map Firestore documents to internal image records.
+- Map internal image records back to Firestore-safe data.
+
+Firestore document shape should align with the internal image record as much as possible.
+
+### 21.3 Firebase Storage Provider
+
+Responsibilities:
+
+- Save objects to Firebase Storage.
+- Delete Firebase Storage objects.
+- Generate public or signed URLs depending on config.
+
+Provider-specific URLs should still be generated at response time, not treated as permanent database truth.
+
+---
+
+## 22. Frontend API Boundary
+
+Frontend feature code should call local API wrappers only.
+
+Recommended files:
+
+```text
+src/api/images.ts
+src/api/auth.ts
+src/config.ts
+```
+
+`src/api/images.ts` should expose provider-neutral functions:
+
+```ts
+export async function getPublicImages(): Promise<PhotogramImage[]> {}
+export async function getMyImages(): Promise<PhotogramImage[]> {}
+export async function uploadImage(input: UploadImageInput): Promise<PhotogramImage> {}
+export async function deleteImage(imageId: string): Promise<void> {}
+```
+
+Components and Redux thunks should not directly import Firestore or Firebase Storage.
+
+Allowed during transition:
+
+- Firebase Auth usage in app initialization/login while `AUTH_PROVIDER=firebase` remains active.
+
+Not allowed after migration of gallery/upload/delete:
+
+- Gallery components reading directly from Firestore.
+- Upload components writing directly to Firebase Storage.
+- Delete flows deleting directly from Firebase Storage.
+- Frontend storing provider-specific object paths as business logic.
+
+Frontend environment:
+
+```env
+REACT_APP_API_URL=https://photos.example.com
+```
+
+Later local-auth mode:
+
+```env
+REACT_APP_API_URL=https://photos.example.com
+```
+
+During the Firebase Auth MVP, login/bootstrap continues to use the existing Firebase `REACT_APP_*` configuration. Frontend gallery/upload/delete code should not receive backend provider-selection env vars; database, storage, and auth provider settings belong to the backend.
+
+---
+
+## 23. Auth Migration Strategy
+
+### Phase A: Keep Firebase Auth
+
+Frontend signs users in with Firebase.
+
+For authenticated backend requests, frontend sends Firebase ID token:
+
+```text
+Authorization: Bearer <firebase-id-token>
+```
+
+Backend validates the token through `AuthProvider=firebase`.
+
+This allows local database/storage migration without immediately rewriting login.
+
+### Phase B: Add Local Auth
+
+Backend implements:
+
+```text
+POST /auth/login
+POST /auth/logout
+GET  /auth/me
+```
+
+Local auth should use:
+
+- password hashing with a safe library
+- HTTP-only cookies
+- `SameSite` cookie settings
+- secure cookies in production behind HTTPS
+- login rate limiting
+- session expiration
+
+Future local-auth login/bootstrap migration should be specified separately. Do not introduce frontend backend-provider env vars for the current Firebase Auth MVP.
+
+---
+
+## 24. Migration Phases
+
+### Phase 1: Backend Composition Layer
+
+Add:
+
+```text
+config/env.js
+config/container.js
+repositories/
+storage/
+auth/
+services/
+```
+
+Goal:
+
+- Existing backend behavior still works.
+- Provider selection is centralized.
+- Controllers/services do not branch on provider names.
+
+### Phase 2: Local Storage Provider
+
+Add `STORAGE_PROVIDER=local`.
+
+Goal:
+
+- `/resize-upload` can save processed images to local filesystem.
+- `/delete-image` can delete local files.
+- Firebase Storage is no longer required for upload/delete in local mode.
+
+### Phase 3: SQLite Image Repository
+
+Add `DATABASE_PROVIDER=sqlite`.
+
+Goal:
+
+- Upload creates SQLite metadata.
+- Delete removes or soft-deletes SQLite metadata.
+- `GET /images/public` and `GET /images/me` return SQLite-backed data.
+
+### Phase 4: Frontend Gallery API Migration
+
+Update frontend gallery flows to use backend API.
+
+Goal:
+
+- Public gallery uses `GET /images/public`.
+- User gallery uses `GET /images/me`.
+- Gallery state no longer depends on Firestore directly.
+
+### Phase 5: Frontend Upload/Delete API Migration
+
+Update frontend upload/delete flows to use canonical backend API.
+
+Goal:
+
+- Upload uses `POST /images` or compatibility `POST /resize-upload`.
+- Delete uses `DELETE /images/:imageId` or compatibility `POST /delete-image`.
+- Components remain provider-agnostic.
+
+### Phase 6: Local Auth
+
+Add `AUTH_PROVIDER=local`.
+
+Goal:
+
+- Firebase is fully optional.
+- Default deployment can be local auth + SQLite + local filesystem.
+
+---
+
+## 25. Testing Requirements
+
+### 25.1 Backend Unit Tests
+
+Use `node:test` and `node:assert/strict`.
+
+Required tests:
+
+- env parsing and defaults
+- invalid provider names fail startup validation
+- missing required env for selected provider fails startup validation
+- provider registry resolves allowed providers only
+- container injects expected service dependencies
+- image DTO mapping calls `storageProvider.getUrl()`
+- SQLite repository creates/list/find/delete image metadata
+- local storage provider rejects path traversal
+- local storage provider saves and deletes objects
+- upload service handles storage failure cleanup
+- delete service handles missing file idempotently where practical
+
+### 25.2 Backend Manual Validation
+
+Validate with `curl` or Postman:
+
+```text
+/health
+/resize
+/upload
+/resize-upload
+/delete-image
+/images/public
+/images/me
+/images/:imageId
+```
+
+For upload endpoints, test:
+
+- valid image
+- non-image file
+- empty payload
+- oversize payload based on `MAX_FILE_SIZE_MB`
+- authenticated request
+- unauthenticated request
+
+### 25.3 Frontend Tests
+
+Use Jest + React Testing Library.
+
+Required tests:
+
+- public gallery renders images from backend API response
+- user gallery renders images from backend API response
+- upload flow calls backend API wrapper
+- delete flow calls backend API wrapper
+- protected route behavior remains correct
+- Firebase-specific gallery/upload behavior is removed or isolated
+
+---
+
+## 26. Security Requirements
+
+1. Do not commit secrets.
+2. Keep Firebase service account JSON outside the repository.
+3. Validate upload MIME type and file extension.
+4. Reject non-image uploads.
+5. Reject oversized uploads.
+6. Prevent path traversal in local storage.
+7. Do not expose private files through public static routes.
+8. Use authorization checks before serving private images.
+9. Use short TTLs for signed URLs when using signed URL mode.
+10. Keep CORS allowlists explicit.
+11. Use rate limits on heavy endpoints.
+12. Avoid debug endpoints in production unless explicitly enabled.
+13. Do not expose raw stack traces to clients in production.
+
+---
+
+## 27. NC110 Operational Requirements
+
+The default local deployment must be realistic for the Samsung NC110.
+
+Requirements:
+
+- Keep image processing concurrency low.
+- Keep memory usage low.
+- Avoid unnecessary daemons.
+- Prefer SQLite over a separate database server initially.
+- Prefer local filesystem over object storage initially.
+- Prefer Nginx/Caddy static serving for public media when configured.
+- Keep PM2 process configuration documented.
+- Validate `sharp` on target hardware; support `jimp` fallback if needed.
+- Test PM2 after deployment:
+
+```text
+pm2 status
+pm2 logs photogram-backend
+```
+
+Suggested local paths:
+
+```text
+/var/lib/photogram/photogram.sqlite
+/var/lib/photogram/images
+/var/backups/photogram
+```
+
+Backup strategy:
+
+```text
+1. Stop or briefly pause writes if necessary.
+2. Copy SQLite database.
+3. Copy image folder.
+4. Store backup outside the application directory.
+5. Periodically test restore.
+```
+
+---
+
+## 28. Files Likely to Change
+
+### Backend
+
+Likely additions:
+
+```text
+config/env.js
+config/container.js
+auth/firebaseAuthProvider.js
+auth/localAuthProvider.js
+repositories/firebaseImageRepository.js
+repositories/sqliteImageRepository.js
+storage/firebaseStorageProvider.js
+storage/localStorageProvider.js
+services/imageService.js
+services/imagePresenter.js
+services/imageProcessor.js
+routes/authRoutes.js
+routes/imageRoutes.js
+controllers/authController.js
+controllers/imageController.js
+tests/config.test.js
+tests/container.test.js
+tests/sqliteImageRepository.test.js
+tests/localStorageProvider.test.js
+tests/imageService.test.js
+```
+
+Likely updates:
+
+```text
+index.js
+app.js
+config/firebase.js
+middleware/upload.js
+middleware/rateLimit.js
+controllers/*
+routes/*
+package.json
+```
+
+### Frontend
+
+Likely additions/updates:
+
+```text
+src/api/images.ts
+src/api/auth.ts
+src/config.ts
+src/state/*
+src/components/Gallery/*
+src/components/Login/*
+src/components/App/AppInitializer.tsx
+src/components/App/ProtectedRoute.tsx
+```
+
+Firebase-specific frontend code should remain only where needed for Firebase Auth during the transition.
+
+---
+
+## 29. Definition of Done
+
+The provider-agnostic migration is done when:
+
+1. Frontend gallery/upload/delete flows call only the Photogram API.
+2. Frontend gallery/upload/delete flows do not directly use Firestore or Firebase Storage.
+3. Backend provider selection happens only in config/composition.
+4. Controllers and services do not branch on provider names.
+5. `DATABASE_PROVIDER=sqlite` works for gallery metadata.
+6. `STORAGE_PROVIDER=local` works for image upload/delete/URL generation.
+7. Firebase mode still works or is intentionally documented as pending.
+8. Tests cover config validation, provider resolution, upload, delete, and gallery list behavior.
+9. Manual validation confirms key endpoints.
+10. Deployment notes confirm NC110-safe runtime settings.
+
+---
+
+## 30. Codex Implementation Guidance
+
+When using Codex, prefer small, focused tasks.
+
+Suggested task order:
+
+1. Add `config/env.js` provider parsing and validation tests.
+2. Add `config/container.js` with provider registries and tests.
+3. Extract current Firebase storage logic into `storage/firebaseStorageProvider.js`.
+4. Add `storage/localStorageProvider.js` and tests.
+5. Extract current Firestore logic into `repositories/firebaseImageRepository.js`.
+6. Add `repositories/sqliteImageRepository.js` and tests.
+7. Add `services/imageService.js` and `services/imagePresenter.js`.
+8. Wire existing upload/delete routes through `imageService`.
+9. Add canonical `/images` routes while preserving compatibility endpoints.
+10. Update frontend `src/api/images.ts` to call backend APIs.
+11. Update gallery state to consume backend image DTOs.
+12. Update upload/delete UI to use backend API wrappers.
+13. Add local auth only after local database and storage are stable.
+
+Each Codex change should include:
+
+- files changed
+- env/config changes
+- tests added or updated
+- manual validation command when endpoint behavior changes
+
+---
+
+## 31. Open Questions
+
+These do not block Phase 1, but should be decided before final local-only mode.
+
+1. Should local delete be hard delete or soft delete by default?
+2. Should original uploads be retained, or only processed images and thumbnails?
+3. Should private images be streamed by Express or served through Nginx `X-Accel-Redirect`?
+4. Should local auth use username/password only, or support passwordless links later?
+5. Should public media URLs include cache-busting versions?
+6. Should image visibility be editable after upload?
+7. Should SQLite migrations be automatic on startup or explicit commands?
+8. Should EXIF metadata be stripped by default?
+9. Should generated files use `.webp` by default, with fallback to `.jpg`?
+10. Should the backend expose paginated image listing in the first migration?
+
+Recommended initial answers:
+
+1. Hard delete for personal deployment.
+2. Do not retain originals unless explicitly enabled.
+3. Stream private files through Express first; optimize later.
+4. Username/password local auth later.
+5. Add `updatedAt` or version query only if caching issues appear.
+6. Not required for first migration.
+7. Automatic lightweight schema initialization is acceptable early.
+8. Strip EXIF by default for privacy.
+9. Prefer `.webp` when supported by processor; fallback to `.jpg` if needed.
+10. Add simple limit/offset or cursor before galleries grow large.
+
+---
+
+## 32. Summary
+
+Photogram should become provider-agnostic by moving all source-specific behavior into backend providers selected at startup.
+
+The frontend should call stable API functions and render normalized DTOs.
+
+The backend should own provider selection, image processing, metadata, storage, URL resolution, authorization, and safety controls.
+
+Firebase remains an available provider, but the intended default path is local services:
+
+```env
+AUTH_PROVIDER=local
+DATABASE_PROVIDER=sqlite
+STORAGE_PROVIDER=local
+```
+
+The safest migration path is:
+
+```text
+Firebase Auth first,
+SQLite metadata next,
+local filesystem storage next,
+frontend API migration next,
+local auth last.
+```

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "start": "GENERATE_SOURCEMAP=false NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "GENERATE_SOURCEMAP=false NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "NODE_OPTIONS=--openssl-legacy-provider react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/api/images.test.ts
+++ b/src/api/images.test.ts
@@ -1,0 +1,432 @@
+const mockCollection = jest.fn(() => ({
+	where: jest.fn().mockReturnThis(),
+	get: jest.fn(),
+	doc: jest.fn(() => ({
+		update: jest.fn().mockResolvedValue(undefined),
+		delete: jest.fn().mockResolvedValue(undefined),
+	})),
+}));
+
+jest.mock('firebase.configuration', () => ({
+	auth: {
+		currentUser: null,
+	},
+	db: {
+		collection: mockCollection,
+	},
+	imagesDbCollection: 'imagesArray',
+}));
+
+const {
+	ApiError,
+	archiveImageById,
+	archiveImage,
+	deleteImage,
+	getPublicImages,
+	getUserImages,
+	listMyImages,
+	listPublicImages,
+	setImagePrivacy,
+	unarchiveImageById,
+	updateImageVisibility,
+	uploadImage,
+} = require('./images') as typeof import('./images');
+
+type MockResponseInput = {
+	ok?: boolean;
+	status?: number;
+	body?: unknown;
+	bodyText?: string;
+};
+
+const makeResponse = ({ ok = true, status = 200, body = {}, bodyText }: MockResponseInput = {}) => ({
+	ok,
+	status,
+	text: jest.fn().mockResolvedValue(bodyText ?? JSON.stringify(body)),
+});
+
+const fetchMock = () => global.fetch as jest.Mock;
+
+const originalApiUrl = process.env.REACT_APP_API_URL;
+
+beforeEach(() => {
+	process.env.REACT_APP_API_URL = 'http://api.test';
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { images: [] } })) as jest.Mock;
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+	if (originalApiUrl === undefined) {
+		delete process.env.REACT_APP_API_URL;
+	} else {
+		process.env.REACT_APP_API_URL = originalApiUrl;
+	}
+});
+
+test('builds URL from REACT_APP_API_URL', async () => {
+	process.env.REACT_APP_API_URL = 'https://photogram-api.example.com';
+
+	await listPublicImages();
+
+	expect(fetchMock()).toHaveBeenCalledWith('https://photogram-api.example.com/images/public', {
+		method: 'GET',
+	});
+});
+
+test('removes trailing slash from API URL', async () => {
+	process.env.REACT_APP_API_URL = 'https://photogram-api.example.com/';
+
+	await listPublicImages();
+
+	expect(fetchMock()).toHaveBeenCalledWith('https://photogram-api.example.com/images/public', {
+		method: 'GET',
+	});
+});
+
+test('listPublicImages calls GET /images/public without Authorization', async () => {
+	await listPublicImages();
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/public', {
+		method: 'GET',
+	});
+	const init = fetchMock().mock.calls[0][1] as RequestInit;
+	expect(init.headers).toBeUndefined();
+});
+
+test('listPublicImages adds limit and offset query params', async () => {
+	await listPublicImages({ limit: 10, offset: 20 });
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/public?limit=10&offset=20', {
+		method: 'GET',
+	});
+});
+
+test('listPublicImages omits query params when missing', async () => {
+	await listPublicImages();
+
+	expect(fetchMock().mock.calls[0][0]).toBe('http://api.test/images/public');
+});
+
+test('listPublicImages returns images from response images array', async () => {
+	const images = [
+		{
+			id: 'image-1',
+			imageUrl: 'https://cdn.test/image-1.jpg',
+			isPublic: true,
+			createdAt: '2026-06-22T00:00:00.000Z',
+		},
+	];
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { images } })) as jest.Mock;
+
+	await expect(listPublicImages()).resolves.toEqual(images);
+});
+
+test('listMyImages requires idToken', async () => {
+	await expect(listMyImages({ idToken: '' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('listMyImages sends Authorization header and calls GET /images/me', async () => {
+	await listMyImages({ idToken: 'token-1', limit: 3, offset: 0 });
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/me?limit=3&offset=0', {
+		method: 'GET',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('listMyImages sends archived query param only when true', async () => {
+	await listMyImages({ idToken: 'token-1', archived: true });
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/me?archived=true', {
+		method: 'GET',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('listMyImages sends includeArchived query param only when true', async () => {
+	await listMyImages({ idToken: 'token-1', includeArchived: true });
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/me?includeArchived=true', {
+		method: 'GET',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('listMyImages omits false archived and includeArchived query params', async () => {
+	await listMyImages({ idToken: 'token-1', archived: false, includeArchived: false });
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/me', {
+		method: 'GET',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('uploadImage requires file', async () => {
+	await expect(uploadImage({ file: undefined as unknown as File, idToken: 'token-1' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('uploadImage requires idToken', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+
+	await expect(uploadImage({ file, idToken: '' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('uploadImage calls POST /images with Authorization and FormData body', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({
+		body: {
+			image: {
+				id: 'image-1',
+				imageUrl: 'https://cdn.test/image-1.jpg',
+				isPublic: false,
+				createdAt: '2026-06-22T00:00:00.000Z',
+			},
+		},
+	})) as jest.Mock;
+
+	await uploadImage({
+		file,
+		idToken: 'token-1',
+		title: 'Title',
+		description: 'Description',
+		isPublic: false,
+	});
+
+	expect(fetchMock()).toHaveBeenCalledTimes(1);
+	const [url, init] = fetchMock().mock.calls[0] as [string, RequestInit];
+	const body = init.body as FormData;
+	expect(url).toBe('http://api.test/images');
+	expect(init.method).toBe('POST');
+	expect(init.headers).toEqual({ Authorization: 'Bearer token-1' });
+	expect(body).toBeInstanceOf(FormData);
+	expect(body.get('image')).toBe(file);
+	expect(body.get('title')).toBe('Title');
+	expect(body.get('description')).toBe('Description');
+	expect(body.get('isPublic')).toBe('false');
+	expect(init.headers).not.toHaveProperty('Content-Type');
+});
+
+test('uploadImage appends isPublic as true string when provided', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({
+		body: {
+			image: {
+				id: 'image-1',
+				imageUrl: 'https://cdn.test/image-1.jpg',
+				isPublic: true,
+				createdAt: '2026-06-22T00:00:00.000Z',
+			},
+		},
+	})) as jest.Mock;
+
+	await uploadImage({ file, idToken: 'token-1', isPublic: true });
+
+	const init = fetchMock().mock.calls[0][1] as RequestInit;
+	expect((init.body as FormData).get('isPublic')).toBe('true');
+});
+
+test('uploadImage returns image from response image object', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	const image = {
+		id: 'image-1',
+		imageUrl: 'https://cdn.test/image-1.jpg',
+		isPublic: true,
+		createdAt: '2026-06-22T00:00:00.000Z',
+	};
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { image } })) as jest.Mock;
+
+	await expect(uploadImage({ file, idToken: 'token-1' })).resolves.toEqual(image);
+});
+
+test('deleteImage requires imageId', async () => {
+	await expect(deleteImage({ imageId: '', idToken: 'token-1' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('deleteImage requires idToken', async () => {
+	await expect(deleteImage({ imageId: 'image-1', idToken: '' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('deleteImage calls DELETE /images/:imageId with encoded id and Authorization', async () => {
+	const result = { imageId: 'folder/image 1', deleted: true };
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: result })) as jest.Mock;
+
+	await expect(deleteImage({ imageId: 'folder/image 1', idToken: 'token-1' })).resolves.toEqual(result);
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/folder%2Fimage%201', {
+		method: 'DELETE',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('updateImageVisibility requires imageId', async () => {
+	await expect(updateImageVisibility({ imageId: '', idToken: 'token-1', isPublic: true })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('updateImageVisibility requires idToken', async () => {
+	await expect(updateImageVisibility({ imageId: 'image-1', idToken: '', isPublic: true })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('updateImageVisibility requires boolean isPublic', async () => {
+	await expect(updateImageVisibility({
+		imageId: 'image-1',
+		idToken: 'token-1',
+		isPublic: undefined as unknown as boolean,
+	})).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('updateImageVisibility calls PATCH visibility endpoint with encoded id, auth, and JSON body', async () => {
+	const image = {
+		id: 'folder/image 1',
+		imageUrl: 'https://cdn.test/image-1.jpg',
+		isPublic: false,
+		createdAt: '2026-06-22T00:00:00.000Z',
+	};
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { image } })) as jest.Mock;
+
+	await expect(updateImageVisibility({
+		imageId: 'folder/image 1',
+		idToken: 'token-1',
+		isPublic: false,
+	})).resolves.toEqual(image);
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/folder%2Fimage%201/visibility', {
+		method: 'PATCH',
+		headers: {
+			Authorization: 'Bearer token-1',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ isPublic: false }),
+	});
+});
+
+test('archiveImageById requires imageId', async () => {
+	await expect(archiveImageById({ imageId: '', idToken: 'token-1' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('archiveImageById requires idToken', async () => {
+	await expect(archiveImageById({ imageId: 'image-1', idToken: '' })).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('archiveImageById calls POST archive endpoint with Authorization and returns image', async () => {
+	const image = {
+		id: 'folder/image 1',
+		imageUrl: 'https://cdn.test/image-1.jpg',
+		isPublic: false,
+		isArchived: true,
+		createdAt: '2026-06-22T00:00:00.000Z',
+	};
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { image } })) as jest.Mock;
+
+	await expect(archiveImageById({ imageId: 'folder/image 1', idToken: 'token-1' })).resolves.toEqual(image);
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/folder%2Fimage%201/archive', {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('unarchiveImageById calls POST unarchive endpoint with Authorization and returns image', async () => {
+	const image = {
+		id: 'folder/image 1',
+		imageUrl: 'https://cdn.test/image-1.jpg',
+		isPublic: false,
+		isArchived: false,
+		createdAt: '2026-06-22T00:00:00.000Z',
+	};
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({ body: { image } })) as jest.Mock;
+
+	await expect(unarchiveImageById({ imageId: 'folder/image 1', idToken: 'token-1' })).resolves.toEqual(image);
+
+	expect(fetchMock()).toHaveBeenCalledWith('http://api.test/images/folder%2Fimage%201/unarchive', {
+		method: 'POST',
+		headers: {
+			Authorization: 'Bearer token-1',
+		},
+	});
+});
+
+test('non-2xx JSON response throws ApiError', async () => {
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({
+		ok: false,
+		status: 400,
+		body: { message: 'Invalid request', code: 'invalid_request', details: { field: 'limit' } },
+	})) as jest.Mock;
+
+	await expect(listPublicImages()).rejects.toMatchObject({
+		name: 'ApiError',
+		status: 400,
+		code: 'invalid_request',
+		message: 'Invalid request',
+		details: { field: 'limit' },
+	});
+});
+
+test('non-2xx non-JSON response throws ApiError', async () => {
+	global.fetch = jest.fn().mockResolvedValue(makeResponse({
+		ok: false,
+		status: 500,
+		bodyText: 'server unavailable',
+	})) as jest.Mock;
+
+	await expect(listPublicImages()).rejects.toMatchObject({
+		name: 'ApiError',
+		status: 500,
+		message: 'Request failed with HTTP 500.',
+	});
+});
+
+test('validation failures do not call fetch', async () => {
+	await expect(listPublicImages({ limit: 0 })).rejects.toThrow(ApiError);
+	await expect(listPublicImages({ offset: -1 })).rejects.toThrow(ApiError);
+
+	delete process.env.REACT_APP_API_URL;
+	await expect(listPublicImages()).rejects.toThrow(ApiError);
+
+	expect(fetchMock()).not.toHaveBeenCalled();
+});
+
+test('existing legacy exports still exist', () => {
+	expect(typeof getPublicImages).toBe('function');
+	expect(typeof getUserImages).toBe('function');
+	expect(typeof archiveImage).toBe('function');
+	expect(typeof archiveImageById).toBe('function');
+	expect(typeof setImagePrivacy).toBe('function');
+	expect(typeof unarchiveImageById).toBe('function');
+	expect(typeof updateImageVisibility).toBe('function');
+	expect(typeof uploadImage).toBe('function');
+	expect(typeof deleteImage).toBe('function');
+});
+
+export {};

--- a/src/api/images.ts
+++ b/src/api/images.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import type firebase from 'firebase/app';
 import { auth, db, imagesDbCollection } from 'firebase.configuration';
 import { ImageInterface } from 'type';
 import config from '../config';
@@ -9,6 +9,326 @@ const imagesRef = db.collection(imagesDbCollection);
 
 type UploadApiResponse = { url?: string };
 type FirestoreTimestampLike = { toMillis: () => number };
+type LegacyUploadOptions = {
+	onProgress?: (percent: number) => void;
+	onStage?: (stage: 'uploading' | 'processing') => void;
+};
+type ApiErrorBody = {
+	error?: unknown;
+	message?: unknown;
+	code?: unknown;
+	details?: unknown;
+};
+
+export interface PhotogramImage {
+	id: string;
+	ownerId?: string;
+	title?: string;
+	description?: string;
+	imageUrl: string;
+	thumbnailUrl?: string;
+	width?: number;
+	height?: number;
+	sizeBytes?: number;
+	mimeType?: string;
+	isPublic: boolean;
+	isArchived?: boolean;
+	archivedAt?: string;
+	createdAt: string;
+	updatedAt?: string;
+}
+
+export interface PaginationOptions {
+	limit?: number;
+	offset?: number;
+}
+
+export interface UploadImageInput {
+	file: File;
+	idToken: string;
+	title?: string;
+	description?: string;
+	isPublic?: boolean;
+}
+
+export interface AuthenticatedImageRequest {
+	idToken: string;
+	limit?: number;
+	offset?: number;
+	archived?: boolean;
+	includeArchived?: boolean;
+}
+
+export interface DeleteImageInput {
+	imageId: string;
+	idToken: string;
+}
+
+export interface DeleteImageResult {
+	imageId: string;
+	deleted: boolean;
+}
+
+export interface UpdateImageVisibilityInput {
+	imageId: string;
+	idToken: string;
+	isPublic: boolean;
+}
+
+export interface ArchiveImageInput {
+	imageId: string;
+	idToken: string;
+}
+
+export class ApiError extends Error {
+	status: number;
+	code?: string;
+	details?: unknown;
+
+	constructor(status: number, message: string, code?: string, details?: unknown) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+		this.code = code;
+		this.details = details;
+		Object.setPrototypeOf(this, ApiError.prototype);
+	}
+}
+
+const getApiBaseUrl = () => {
+	const apiBaseUrl = process.env.REACT_APP_API_URL?.trim() ?? '';
+
+	if (!apiBaseUrl) {
+		throw new ApiError(0, 'REACT_APP_API_URL is required to call the Photogram API.', 'missing_api_url');
+	}
+
+	return apiBaseUrl.replace(/\/+$/, '');
+};
+
+const assertIdToken = (idToken: string) => {
+	if (!idToken?.trim()) {
+		throw new ApiError(0, 'An idToken is required for this request.', 'missing_id_token');
+	}
+};
+
+const assertImageId = (imageId: string, action: string) => {
+	if (!imageId?.trim()) {
+		throw new ApiError(0, `imageId is required to ${action} an image.`, 'missing_image_id');
+	}
+};
+
+const assertBoolean = (value: unknown, fieldName: string) => {
+	if (typeof value !== 'boolean') {
+		throw new ApiError(0, `${fieldName} must be a boolean.`, `invalid_${fieldName}`);
+	}
+};
+
+const assertPagination = (options?: PaginationOptions) => {
+	if (options?.limit !== undefined && (!Number.isInteger(options.limit) || options.limit <= 0)) {
+		throw new ApiError(0, 'limit must be a positive integer.', 'invalid_limit');
+	}
+
+	if (options?.offset !== undefined && (!Number.isInteger(options.offset) || options.offset < 0)) {
+		throw new ApiError(0, 'offset must be a non-negative integer.', 'invalid_offset');
+	}
+};
+
+const buildApiUrl = (path: string, options?: PaginationOptions & { archived?: boolean; includeArchived?: boolean }) => {
+	assertPagination(options);
+
+	const url = new URL(`${getApiBaseUrl()}${path}`);
+	if (options?.limit !== undefined) url.searchParams.set('limit', String(options.limit));
+	if (options?.offset !== undefined) url.searchParams.set('offset', String(options.offset));
+	if (options?.archived === true) url.searchParams.set('archived', 'true');
+	if (options?.includeArchived === true) url.searchParams.set('includeArchived', 'true');
+	return url.toString();
+};
+
+const parseJsonBody = async (response: Response): Promise<unknown> => {
+	const bodyText = await response.text();
+	if (!bodyText) return {};
+
+	try {
+		return JSON.parse(bodyText);
+	} catch {
+		return undefined;
+	}
+};
+
+const isApiErrorBody = (body: unknown): body is ApiErrorBody =>
+	Boolean(body && typeof body === 'object');
+
+const getApiErrorMessage = (body: unknown, status: number) => {
+	if (!isApiErrorBody(body)) return `Request failed with HTTP ${status}.`;
+
+	if (typeof body.message === 'string' && body.message.trim()) return body.message;
+	if (typeof body.error === 'string' && body.error.trim()) return body.error;
+
+	if (body.error && typeof body.error === 'object') {
+		const nested = body.error as ApiErrorBody;
+		if (typeof nested.message === 'string' && nested.message.trim()) return nested.message;
+		if (typeof nested.code === 'string' && nested.code.trim()) return nested.code;
+	}
+
+	if (typeof body.code === 'string' && body.code.trim()) return body.code;
+	return `Request failed with HTTP ${status}.`;
+};
+
+const getApiErrorCode = (body: unknown) => {
+	if (!isApiErrorBody(body)) return undefined;
+	if (typeof body.code === 'string') return body.code;
+	if (body.error && typeof body.error === 'object') {
+		const nested = body.error as ApiErrorBody;
+		if (typeof nested.code === 'string') return nested.code;
+	}
+	return undefined;
+};
+
+const requestJson = async <T>(url: string, init?: RequestInit): Promise<T> => {
+	const response = await fetch(url, init);
+	const body = await parseJsonBody(response);
+
+	if (!response.ok) {
+		throw new ApiError(response.status, getApiErrorMessage(body, response.status), getApiErrorCode(body), isApiErrorBody(body) ? body.details : body);
+	}
+
+	return body as T;
+};
+
+export const listPublicImages = async (options?: PaginationOptions): Promise<PhotogramImage[]> => {
+	const response = await requestJson<{ images?: PhotogramImage[] }>(buildApiUrl('/images/public', options), {
+		method: 'GET',
+	});
+
+	return response.images ?? [];
+};
+
+export const listMyImages = async (input: AuthenticatedImageRequest): Promise<PhotogramImage[]> => {
+	assertIdToken(input.idToken);
+
+	const response = await requestJson<{ images?: PhotogramImage[] }>(
+		buildApiUrl('/images/me', {
+			limit: input.limit,
+			offset: input.offset,
+			archived: input.archived,
+			includeArchived: input.includeArchived,
+		}),
+		{
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${input.idToken}`,
+			},
+		},
+	);
+
+	return response.images ?? [];
+};
+
+const uploadPhotogramImage = async (input: UploadImageInput): Promise<PhotogramImage> => {
+	if (!input.file) {
+		throw new ApiError(0, 'A file is required to upload an image.', 'missing_file');
+	}
+
+	assertIdToken(input.idToken);
+
+	const formData = new FormData();
+	formData.append('image', input.file);
+	if (input.title !== undefined) formData.append('title', input.title);
+	if (input.description !== undefined) formData.append('description', input.description);
+	if (input.isPublic !== undefined) formData.append('isPublic', String(input.isPublic));
+
+	const response = await requestJson<{ image?: PhotogramImage }>(buildApiUrl('/images'), {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${input.idToken}`,
+		},
+		body: formData,
+	});
+
+	if (!response.image) {
+		throw new ApiError(0, 'Upload response did not include an image.', 'invalid_upload_response');
+	}
+
+	return response.image;
+};
+
+const deletePhotogramImage = async (input: DeleteImageInput): Promise<DeleteImageResult> => {
+	assertImageId(input.imageId, 'delete');
+	assertIdToken(input.idToken);
+
+	return requestJson<DeleteImageResult>(buildApiUrl(`/images/${encodeURIComponent(input.imageId)}`), {
+		method: 'DELETE',
+		headers: {
+			Authorization: `Bearer ${input.idToken}`,
+		},
+	});
+};
+
+export const updateImageVisibility = async (input: UpdateImageVisibilityInput): Promise<PhotogramImage> => {
+	assertImageId(input.imageId, 'update');
+	assertIdToken(input.idToken);
+	assertBoolean(input.isPublic, 'isPublic');
+
+	const response = await requestJson<{ image?: PhotogramImage }>(
+		buildApiUrl(`/images/${encodeURIComponent(input.imageId)}/visibility`),
+		{
+			method: 'PATCH',
+			headers: {
+				Authorization: `Bearer ${input.idToken}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ isPublic: input.isPublic }),
+		},
+	);
+
+	if (!response.image) {
+		throw new ApiError(0, 'Visibility response did not include an image.', 'invalid_visibility_response');
+	}
+
+	return response.image;
+};
+
+export const archiveImageById = async (input: ArchiveImageInput): Promise<PhotogramImage> => {
+	assertImageId(input.imageId, 'archive');
+	assertIdToken(input.idToken);
+
+	const response = await requestJson<{ image?: PhotogramImage }>(
+		buildApiUrl(`/images/${encodeURIComponent(input.imageId)}/archive`),
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${input.idToken}`,
+			},
+		},
+	);
+
+	if (!response.image) {
+		throw new ApiError(0, 'Archive response did not include an image.', 'invalid_archive_response');
+	}
+
+	return response.image;
+};
+
+export const unarchiveImageById = async (input: ArchiveImageInput): Promise<PhotogramImage> => {
+	assertImageId(input.imageId, 'unarchive');
+	assertIdToken(input.idToken);
+
+	const response = await requestJson<{ image?: PhotogramImage }>(
+		buildApiUrl(`/images/${encodeURIComponent(input.imageId)}/unarchive`),
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${input.idToken}`,
+			},
+		},
+	);
+
+	if (!response.image) {
+		throw new ApiError(0, 'Unarchive response did not include an image.', 'invalid_unarchive_response');
+	}
+
+	return response.image;
+};
 
 const getAuthToken = async (): Promise<string> => {
 	const user = auth.currentUser;
@@ -82,13 +402,9 @@ export const archiveImage = async (image: ImageInterface, imgArchived: boolean) 
 	await imageDocRef.update({ imgArchived: !imgArchived });
 };
 
-// Function to upload an image to the backend service
-export const uploadImage = async (
+const uploadLegacyImage = async (
 	image: File,
-	options?: {
-		onProgress?: (percent: number) => void;
-		onStage?: (stage: 'uploading' | 'processing') => void;
-	},
+	options?: LegacyUploadOptions,
 ): Promise<string | null> => {
 	const formData = new FormData();
 	formData.append('image', image);
@@ -147,8 +463,17 @@ export const uploadImage = async (
 	}
 };
 
-// Function to delete an image both from Firestore and Firebase Storage via backend
-export const deleteImage = async (image: ImageInterface) => {
+export function uploadImage(input: UploadImageInput): Promise<PhotogramImage>;
+export function uploadImage(image: File, options?: LegacyUploadOptions): Promise<string | null>;
+export function uploadImage(input: UploadImageInput | File, options?: LegacyUploadOptions): Promise<PhotogramImage | string | null> {
+	if ('file' in input && 'idToken' in input) {
+		return uploadPhotogramImage(input);
+	}
+
+	return uploadLegacyImage(input, options);
+}
+
+const deleteLegacyImage = async (image: ImageInterface) => {
 	if (!image.imgName) {
 		throw new Error('Missing image name. Cannot delete storage object.');
 	}
@@ -186,3 +511,13 @@ export const deleteImage = async (image: ImageInterface) => {
 		throw new Error(`Storage deleted but Firestore delete failed: ${message}`);
 	}
 };
+
+export function deleteImage(input: DeleteImageInput): Promise<DeleteImageResult>;
+export function deleteImage(image: ImageInterface): Promise<void>;
+export function deleteImage(input: DeleteImageInput | ImageInterface): Promise<DeleteImageResult | void> {
+	if ('imageId' in input && 'idToken' in input) {
+		return deletePhotogramImage(input);
+	}
+
+	return deleteLegacyImage(input);
+}

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,2 +1,25 @@
-export { getPublicImages, getUserImages, archiveImage, deleteImage, uploadImage, setImagePrivacy } from './images';
+export {
+	ApiError,
+	getPublicImages,
+	getUserImages,
+	updateImageVisibility,
+	listMyImages,
+	listPublicImages,
+	archiveImageById,
+	unarchiveImageById,
+	archiveImage,
+	deleteImage,
+	uploadImage,
+	setImagePrivacy,
+} from './images';
+export type {
+	AuthenticatedImageRequest,
+	ArchiveImageInput,
+	DeleteImageInput,
+	DeleteImageResult,
+	PaginationOptions,
+	PhotogramImage,
+	UpdateImageVisibilityInput,
+	UploadImageInput,
+} from './images';
 export { getUserData } from './users';

--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -34,6 +34,7 @@ jest.mock('state', () => {
 			clearImages: () => ({ type: 'CLEAR_IMAGES' }),
 			archiveImage: () => ({ type: 'ARCHIVE_IMAGE' }),
 			togglePrivateImage: () => ({ type: 'TOGGLE_PRIVATE_IMAGE' }),
+			deleteImage: () => ({ type: 'DELETE_IMAGE' }),
 			setUserUID: (uid: string | null) => ({ type: 'SET_USER_UID', uid }),
 			setAsyncStatus: () => ({ type: 'SET_ASYNC_STATUS', feature: 'auth', status: 'idle', error: null }),
 		},
@@ -104,6 +105,39 @@ test('renders gallery route with empty-state message for signed-out users', asyn
 	expect(screen.queryByRole('link', { name: 'Upload' })).not.toBeInTheDocument();
 });
 
+test('renders public gallery images from mapped backend image URLs', async () => {
+	mockState.images = [
+		{
+			imgArchived: false,
+			imgDescription: 'A backend image',
+			imgId: 'image-1',
+			imgLikes: 0,
+			imgName: 'Backend image',
+			imgPrivate: false,
+			imgSrc: 'https://cdn.test/image-1.jpg',
+			imgUploadDate: Date.parse('2026-06-22T12:00:00.000Z'),
+			imgUserOwner: 'owner-1',
+		},
+	];
+
+	renderAppAt('/');
+
+	const image = await screen.findByRole('img', { name: 'Backend image' });
+	expect(image).toHaveAttribute('src', 'https://cdn.test/image-1.jpg');
+	expect(screen.getByRole('link', { name: 'Login' })).toBeInTheDocument();
+});
+
+test('renders public gallery error state', async () => {
+	mockState.requestStatus.publicGallery = {
+		status: 'failed',
+		error: 'Unable to load images: API unavailable',
+	};
+
+	renderAppAt('/');
+
+	expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load images: API unavailable');
+});
+
 test('renders login route and login form fields', async () => {
 	renderAppAt('/login');
 
@@ -126,6 +160,53 @@ test('redirects signed-out users from my gallery to login with next path', async
 	expect(await screen.findByPlaceholderText('Email')).toBeInTheDocument();
 	expect(window.location.pathname).toBe('/login');
 	expect(window.location.search).toContain('next=%2Fmygallery');
+});
+
+test('renders my gallery empty state for authenticated users', async () => {
+	mockAuthUser = { uid: 'user-123' };
+	mockState.auth.uid = 'user-123';
+
+	renderAppAt('/mygallery');
+
+	expect(await screen.findByText('No images available')).toBeInTheDocument();
+	expect(screen.getByText('Show Archived')).toBeInTheDocument();
+});
+
+test('renders my gallery images from mapped backend image URLs', async () => {
+	mockAuthUser = { uid: 'user-123' };
+	mockState.auth.uid = 'user-123';
+	mockState.userImages = [
+		{
+			imgArchived: false,
+			imgDescription: 'A backend user image',
+			imgId: 'user-image-1',
+			imgLikes: 0,
+			imgName: 'My backend image',
+			imgPrivate: true,
+			imgSrc: 'https://cdn.test/user-image-1.jpg',
+			imgUploadDate: Date.parse('2026-06-23T12:00:00.000Z'),
+			imgUserOwner: 'user-123',
+		},
+	];
+
+	renderAppAt('/mygallery');
+
+	const image = await screen.findByRole('img', { name: 'My backend image' });
+	expect(image).toHaveAttribute('src', 'https://cdn.test/user-image-1.jpg');
+	expect(screen.getByText('Show Archived')).toBeInTheDocument();
+});
+
+test('renders my gallery error state', async () => {
+	mockAuthUser = { uid: 'user-123' };
+	mockState.auth.uid = 'user-123';
+	mockState.requestStatus.userGallery = {
+		status: 'failed',
+		error: 'Unable to load images: API unavailable',
+	};
+
+	renderAppAt('/mygallery');
+
+	expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load images: API unavailable');
 });
 
 test('shows authenticated menu items when auth user exists', async () => {

--- a/src/components/Gallery/ShowGallery/ShowGallery.test.tsx
+++ b/src/components/Gallery/ShowGallery/ShowGallery.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import * as Api from 'api';
+import { ShowGallery } from './ShowGallery';
+
+const image = {
+	imgId: 'backend-image-1',
+	imgArchived: false,
+	imgDescription: 'Delete me',
+	imgLikes: 0,
+	imgName: 'Backend image',
+	imgPrivate: false,
+	imgSrc: 'https://cdn.test/backend-image-1.jpg',
+	imgUploadDate: Date.parse('2026-06-23T12:00:00.000Z'),
+	imgUserOwner: 'user-123',
+};
+
+let mockCurrentUser: { getIdToken: jest.Mock } | null = null;
+let mockState = {
+	auth: { uid: 'user-123' as string | null },
+	images: [] as typeof image[],
+	userImages: [image] as typeof image[],
+	requestStatus: {
+		publicGallery: { status: 'idle', error: null as string | null },
+		userGallery: { status: 'idle', error: null as string | null },
+	},
+};
+const mockDispatch: jest.Mock<unknown, [unknown]> = jest.fn();
+const mockFirestoreCollection = jest.fn();
+
+jest.mock('api', () => ({
+	archiveImage: jest.fn(),
+	archiveImageById: jest.fn(),
+	deleteImage: jest.fn(),
+	listMyImages: jest.fn(),
+	listPublicImages: jest.fn(),
+	setImagePrivacy: jest.fn(),
+	unarchiveImageById: jest.fn(),
+	updateImageVisibility: jest.fn(),
+}));
+
+jest.mock('firebase.configuration', () => ({
+	auth: {
+		get currentUser() {
+			return mockCurrentUser;
+		},
+	},
+	db: {
+		collection: (collectionName: string) => mockFirestoreCollection(collectionName),
+	},
+	imagesDbCollection: 'imagesArray',
+}));
+
+jest.mock('react-redux', () => ({
+	useDispatch: () => mockDispatch,
+	useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+}));
+
+const deleteImageMock = Api.deleteImage as jest.Mock;
+const listMyImagesMock = Api.listMyImages as jest.Mock;
+const archiveImageByIdMock = Api.archiveImageById as jest.Mock;
+const legacyArchiveImageMock = Api.archiveImage as jest.Mock;
+const setImagePrivacyMock = Api.setImagePrivacy as jest.Mock;
+const unarchiveImageByIdMock = Api.unarchiveImageById as jest.Mock;
+const updateImageVisibilityMock = Api.updateImageVisibility as jest.Mock;
+
+const renderGallery = () => render(
+	<MemoryRouter>
+		<ShowGallery uid="user-123" />
+	</MemoryRouter>,
+);
+
+beforeEach(() => {
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('id-token-1') };
+	mockState = {
+		auth: { uid: 'user-123' },
+		images: [],
+		userImages: [image],
+		requestStatus: {
+			publicGallery: { status: 'idle', error: null },
+			userGallery: { status: 'idle', error: null },
+		},
+	};
+	mockDispatch.mockClear();
+	mockDispatch.mockImplementation((action: unknown) => {
+		if (typeof action === 'function') {
+			return action(mockDispatch);
+		}
+
+		return action;
+	});
+	mockFirestoreCollection.mockClear();
+	archiveImageByIdMock.mockReset();
+	deleteImageMock.mockReset();
+	legacyArchiveImageMock.mockReset();
+	listMyImagesMock.mockReset();
+	setImagePrivacyMock.mockReset();
+	unarchiveImageByIdMock.mockReset();
+	updateImageVisibilityMock.mockReset();
+	archiveImageByIdMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		isArchived: true,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+	listMyImagesMock.mockResolvedValue([]);
+	unarchiveImageByIdMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		isArchived: false,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+	updateImageVisibilityMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+});
+
+test('hide button dispatches migrated visibility action', async () => {
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Make image private' }));
+
+	await waitFor(() => {
+		expect(updateImageVisibilityMock).toHaveBeenCalledWith({
+			imageId: 'backend-image-1',
+			idToken: 'id-token-1',
+			isPublic: false,
+		});
+	});
+	expect(setImagePrivacyMock).not.toHaveBeenCalled();
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+});
+
+test('show button dispatches migrated visibility action', async () => {
+	mockState.userImages = [{ ...image, imgPrivate: true }];
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Make image public' }));
+
+	await waitFor(() => {
+		expect(updateImageVisibilityMock).toHaveBeenCalledWith({
+			imageId: 'backend-image-1',
+			idToken: 'id-token-1',
+			isPublic: true,
+		});
+	});
+	expect(setImagePrivacyMock).not.toHaveBeenCalled();
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+});
+
+test('archive button dispatches migrated archive action', async () => {
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Archive image' }));
+
+	await waitFor(() => {
+		expect(archiveImageByIdMock).toHaveBeenCalledWith({
+			imageId: 'backend-image-1',
+			idToken: 'id-token-1',
+		});
+	});
+	expect(legacyArchiveImageMock).not.toHaveBeenCalled();
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+});
+
+test('unarchive button dispatches migrated unarchive action', async () => {
+	mockState.userImages = [{ ...image, imgArchived: true }];
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Unarchive image' }));
+
+	await waitFor(() => {
+		expect(unarchiveImageByIdMock).toHaveBeenCalledWith({
+			imageId: 'backend-image-1',
+			idToken: 'id-token-1',
+		});
+	});
+	expect(legacyArchiveImageMock).not.toHaveBeenCalled();
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+});
+
+test('show archived toggle loads archived backend images', async () => {
+	renderGallery();
+
+	await waitFor(() => expect(listMyImagesMock).toHaveBeenCalledWith({ idToken: 'id-token-1' }));
+	fireEvent.click(screen.getByText('Show Archived'));
+
+	await waitFor(() => expect(listMyImagesMock).toHaveBeenCalledWith({
+		idToken: 'id-token-1',
+		archived: true,
+	}));
+});
+
+test('user-facing delete calls canonical delete API and refreshes my gallery on success', async () => {
+	let resolveDelete: () => void = () => undefined;
+	const deletePromise = new Promise((resolve) => {
+		resolveDelete = () => resolve({ imageId: 'backend-image-1', deleted: true });
+	});
+	deleteImageMock.mockReturnValue(deletePromise);
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Delete image' }));
+
+	expect(screen.getByRole('button', { name: 'Deleting image' })).toBeDisabled();
+	await waitFor(() => {
+		expect(deleteImageMock).toHaveBeenCalledWith({
+			imageId: 'backend-image-1',
+			idToken: 'id-token-1',
+		});
+	});
+	expect(deleteImageMock.mock.calls[0][0]).not.toBe(image);
+	expect(deleteImageMock.mock.calls[0][0]).not.toMatchObject({
+		imageId: 'https://cdn.test/backend-image-1.jpg',
+	});
+	expect(deleteImageMock.mock.calls[0][0]).not.toHaveProperty('uid');
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+
+	await act(async () => {
+		resolveDelete();
+		await deletePromise;
+	});
+
+	await waitFor(() => {
+		expect(screen.getByRole('status')).toHaveTextContent('Image deleted successfully.');
+	});
+	expect(listMyImagesMock).toHaveBeenCalledTimes(2);
+	expect(screen.getByRole('button', { name: 'Delete image' })).not.toBeDisabled();
+});
+
+test('user-facing delete preserves error notice when delete fails', async () => {
+	let rejectDelete: (error: Error) => void = () => undefined;
+	const deletePromise = new Promise((_, reject) => {
+		rejectDelete = reject;
+	});
+	deleteImageMock.mockReturnValue(deletePromise);
+	renderGallery();
+
+	fireEvent.click(screen.getByRole('button', { name: 'Delete image' }));
+
+	await waitFor(() => expect(deleteImageMock).toHaveBeenCalledTimes(1));
+	await act(async () => {
+		rejectDelete(new Error('Delete failed'));
+		try {
+			await deletePromise;
+		} catch {
+			// Expected: the component catches this and shows the error notice.
+		}
+	});
+
+	expect(await screen.findByRole('status')).toHaveTextContent('Delete failed');
+	expect(listMyImagesMock).toHaveBeenCalledTimes(1);
+	expect(mockFirestoreCollection).not.toHaveBeenCalled();
+});
+
+export {};

--- a/src/components/Gallery/ShowGallery/ShowGallery.tsx
+++ b/src/components/Gallery/ShowGallery/ShowGallery.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch } from 'state/store';
 import { useLocation } from 'react-router-dom';
-import { deleteImage } from 'api';
 import { ArchiveImage, DeleteImage, HideImage, ModalImage, OverlayLayer } from 'components';
 import { actionCreators } from 'state';
 import { RootState } from 'state/reducers';
@@ -77,12 +76,11 @@ const ShowGalleryInternal: React.FC<ComponentProps> = ({ uid }) => {
 	};
 
 	const handleDeleteImage = async (data: ImageInterface) => {
-		const imageId = data.imgId ?? data.imgName;
-		setIsDeletingId(imageId);
+		setIsDeletingId(data.imgId ?? null);
 		setDeleteStatus(null);
 
 		try {
-			await deleteImage(data);
+			await dispatch(actionCreators.deleteImage(data));
 			await refreshGallery();
 			setDeleteStatus({ kind: 'success', message: 'Image deleted successfully.' });
 		} catch (error) {

--- a/src/components/Gallery/UploadImage/UploadImage.test.tsx
+++ b/src/components/Gallery/UploadImage/UploadImage.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { uploadImage } from 'api';
+import { UploadImage } from './UploadImage';
+
+let mockUid: string | null = 'user-123';
+let mockCurrentUser: { getIdToken: jest.Mock } | null = null;
+const mockDispatch = jest.fn();
+const mockFirestoreAdd = jest.fn();
+const mockCollection = jest.fn((collectionName?: string) => ({
+	collectionName,
+	add: mockFirestoreAdd,
+}));
+
+jest.mock('api', () => ({
+	uploadImage: jest.fn(),
+}));
+
+jest.mock('firebase.configuration', () => ({
+	auth: {
+		get currentUser() {
+			return mockCurrentUser;
+		},
+	},
+	db: {
+		collection: (collectionName: string) => mockCollection(collectionName),
+	},
+	imagesDbCollection: 'imagesArray',
+}));
+
+jest.mock('react-redux', () => ({
+	useDispatch: () => mockDispatch,
+	useSelector: (selector: (state: { auth: { uid: string | null } }) => unknown) => selector({ auth: { uid: mockUid } }),
+}));
+
+jest.mock('state', () => ({
+	actionCreators: {
+		setAsyncStatus: (feature: string, status: string, error: string | null = null) => ({
+			type: 'SET_ASYNC_STATUS',
+			feature,
+			status,
+			error,
+		}),
+	},
+}));
+
+const uploadImageMock = uploadImage as jest.Mock;
+const createObjectURLMock = jest.fn(() => 'blob:test-preview');
+const revokeObjectURLMock = jest.fn();
+
+const renderUpload = () => render(
+	<MemoryRouter>
+		<UploadImage />
+	</MemoryRouter>,
+);
+
+const selectFile = (file: File) => {
+	const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+	fireEvent.change(input, { target: { files: [file] } });
+};
+
+beforeAll(() => {
+	Object.defineProperty(URL, 'createObjectURL', {
+		writable: true,
+		value: createObjectURLMock,
+	});
+	Object.defineProperty(URL, 'revokeObjectURL', {
+		writable: true,
+		value: revokeObjectURLMock,
+	});
+});
+
+beforeEach(() => {
+	mockUid = 'user-123';
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('id-token-1') };
+	mockDispatch.mockClear();
+	mockFirestoreAdd.mockClear();
+	mockCollection.mockClear();
+	createObjectURLMock.mockClear();
+	revokeObjectURLMock.mockClear();
+	uploadImageMock.mockReset();
+	uploadImageMock.mockResolvedValue({
+		id: 'image-1',
+		ownerId: 'user-123',
+		description: 'A backend upload',
+		imageUrl: 'https://cdn.test/image-1.jpg',
+		isPublic: true,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+});
+
+test('upload flow obtains an ID token and calls canonical uploadImage input', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	renderUpload();
+
+	selectFile(file);
+	fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'A backend upload' } });
+	fireEvent.click(screen.getByLabelText('Private'));
+	fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+	await waitFor(() => expect(uploadImageMock).toHaveBeenCalledTimes(1));
+
+	expect(mockCurrentUser?.getIdToken).toHaveBeenCalledWith();
+	expect(uploadImageMock).toHaveBeenCalledWith({
+		file,
+		idToken: 'id-token-1',
+		description: 'A backend upload',
+		isPublic: false,
+	});
+	expect(uploadImageMock.mock.calls[0][0]).not.toBe(file);
+	expect(mockFirestoreAdd).not.toHaveBeenCalled();
+	expect(mockCollection).not.toHaveBeenCalled();
+	expect(await screen.findByText('Uploaded')).toBeInTheDocument();
+	expect(screen.getByRole('link', { name: 'Open image' })).toHaveAttribute('href', 'https://cdn.test/image-1.jpg');
+});
+
+test('upload flow preserves public default privacy', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	renderUpload();
+
+	selectFile(file);
+	fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+	await waitFor(() => expect(uploadImageMock).toHaveBeenCalledTimes(1));
+
+	expect(uploadImageMock.mock.calls[0][0]).toMatchObject({
+		file,
+		idToken: 'id-token-1',
+		isPublic: true,
+	});
+});
+
+test('upload flow fails when Firebase current user is missing', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	mockCurrentUser = null;
+	renderUpload();
+
+	selectFile(file);
+	fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+	expect(await screen.findByRole('alert')).toHaveTextContent('Please log in to upload images.');
+	expect(uploadImageMock).not.toHaveBeenCalled();
+	expect(mockFirestoreAdd).not.toHaveBeenCalled();
+});
+
+test('upload flow surfaces token retrieval failures', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	mockCurrentUser = { getIdToken: jest.fn().mockRejectedValue(new Error('Token unavailable')) };
+	renderUpload();
+
+	selectFile(file);
+	fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+	expect(await screen.findByRole('alert')).toHaveTextContent('Token unavailable');
+	expect(uploadImageMock).not.toHaveBeenCalled();
+	expect(mockFirestoreAdd).not.toHaveBeenCalled();
+});
+
+test('upload flow surfaces API upload failures', async () => {
+	const file = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+	uploadImageMock.mockRejectedValue(new Error('Upload failed'));
+	renderUpload();
+
+	selectFile(file);
+	fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+	expect(await screen.findByRole('alert')).toHaveTextContent('Upload failed');
+	expect(mockFirestoreAdd).not.toHaveBeenCalled();
+});
+
+export {};

--- a/src/components/Gallery/UploadImage/UploadImage.tsx
+++ b/src/components/Gallery/UploadImage/UploadImage.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { db, imagesDbCollection } from 'firebase.configuration';
+import { auth } from 'firebase.configuration';
 import { uploadImage } from 'api';
 import type { AppDispatch } from 'state';
 import { actionCreators } from 'state';
@@ -11,8 +11,8 @@ import './UploadImage.css';
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10MB
 
-type UploadStatus = 'idle' | 'uploading' | 'saving' | 'success' | 'error';
-type UploadStageLabel = 'Uploading…' | 'Processing…' | null;
+type UploadStatus = 'idle' | 'uploading' | 'success' | 'error';
+type UploadStageLabel = 'Uploading…' | null;
 
 export const UploadImage: React.FC = () => {
 	const inputIdRef = React.useRef(`fileInput-${Math.random().toString(36).slice(2)}`);
@@ -31,7 +31,7 @@ export const UploadImage: React.FC = () => {
 	const dispatch = useDispatch<AppDispatch>();
 	logger.debug('User UID:', userUID);
 
-	const isBusy = status === 'uploading' || status === 'saving';
+	const isBusy = status === 'uploading';
 	const canUpload = Boolean(userUID) && Boolean(image) && !isBusy;
 
 	const fileMeta = useMemo(() => {
@@ -111,6 +111,15 @@ export const UploadImage: React.FC = () => {
 
 		if (!image || isBusy) return;
 
+		const currentUser = auth.currentUser;
+		if (!currentUser) {
+			const message = 'Please log in to upload images.';
+			setErrorMessage(message);
+			setStatus('error');
+			dispatch(actionCreators.setAsyncStatus('upload', 'failed', message));
+			return;
+		}
+
 		setErrorMessage(null);
 		setUploadPercent(0);
 		setUploadStage('Uploading…');
@@ -118,30 +127,21 @@ export const UploadImage: React.FC = () => {
 		dispatch(actionCreators.setAsyncStatus('upload', 'loading'));
 
 		try {
-			const url = await uploadImage(image, {
-				onProgress: setUploadPercent,
-				onStage: (stage) => setUploadStage(stage === 'uploading' ? 'Uploading…' : 'Processing…'),
+			const idToken = await currentUser.getIdToken();
+			const uploadedImage = await uploadImage({
+				file: image,
+				idToken,
+				description: imageDescription || undefined,
+				isPublic: !isPrivate,
 			});
-			if (!url) throw new Error('Upload failed.');
+			if (!uploadedImage.imageUrl) throw new Error('Upload failed.');
 
 			setUploadStage(null);
-			setStatus('saving');
-			await db.collection(imagesDbCollection).add({
-				imgArchived: false,
-				imgDescription: imageDescription || '',
-				imgLikes: 0,
-				imgName: image.name,
-				imgPrivate: isPrivate,
-				imgSrc: url,
-				imgUploadDate: Date.now(),
-				imgUserOwner: userUID,
-			});
-
-			setUploadedUrl(url);
+			setUploadedUrl(uploadedImage.imageUrl);
 			setStatus('success');
 			setUploadPercent(100);
 			dispatch(actionCreators.setAsyncStatus('upload', 'succeeded'));
-			logger.debug('Image uploaded and saved');
+			logger.debug('Image uploaded');
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.error('Error uploading image:', error);
@@ -264,8 +264,6 @@ export const UploadImage: React.FC = () => {
 					<div className="progressBarWrap">
 						{status === 'uploading' ? (
 							<progress className="progressBar" value={uploadPercent} max={100} />
-						) : status === 'saving' ? (
-							<progress className="progressBar" />
 						) : status === 'success' ? (
 							<progress className="progressBar" value={100} max={100} />
 						) : (
@@ -275,7 +273,7 @@ export const UploadImage: React.FC = () => {
 
 					<div className="buttonWrap">
 						<button className="buttonMain" onClick={handleUpload} disabled={!canUpload}>
-							{status === 'uploading' ? 'Uploading…' : status === 'saving' ? 'Saving…' : 'Upload'}
+							{status === 'uploading' ? 'Uploading…' : 'Upload'}
 						</button>
 						<button
 							type="button"

--- a/src/state/actionCreators/index.test.ts
+++ b/src/state/actionCreators/index.test.ts
@@ -1,0 +1,617 @@
+import { ActionType } from '../actionTypes';
+import { archiveImage as archiveImageAction, deleteImage, loadImages, loadUserImages, togglePrivateImage } from './index';
+import * as Api from 'api';
+
+let mockCurrentUser: { getIdToken: jest.Mock } | null = null;
+
+jest.mock('api', () => ({
+	archiveImage: jest.fn(),
+	archiveImageById: jest.fn(),
+	getPublicImages: jest.fn(),
+	getUserImages: jest.fn(),
+	deleteImage: jest.fn(),
+	listMyImages: jest.fn(),
+	listPublicImages: jest.fn(),
+	setImagePrivacy: jest.fn(),
+	unarchiveImageById: jest.fn(),
+	updateImageVisibility: jest.fn(),
+}));
+
+jest.mock('firebase.configuration', () => ({
+	auth: {
+		get currentUser() {
+			return mockCurrentUser;
+		},
+	},
+}));
+
+const listPublicImagesMock = Api.listPublicImages as jest.Mock;
+const getPublicImagesMock = Api.getPublicImages as jest.Mock;
+const listMyImagesMock = Api.listMyImages as jest.Mock;
+const getUserImagesMock = Api.getUserImages as jest.Mock;
+const deleteImageMock = Api.deleteImage as jest.Mock;
+const legacyArchiveImageMock = Api.archiveImage as jest.Mock;
+const archiveImageByIdMock = Api.archiveImageById as jest.Mock;
+const setImagePrivacyMock = Api.setImagePrivacy as jest.Mock;
+const unarchiveImageByIdMock = Api.unarchiveImageById as jest.Mock;
+const updateImageVisibilityMock = Api.updateImageVisibility as jest.Mock;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	mockCurrentUser = null;
+});
+
+test('public gallery load path calls listPublicImages without requiring auth', async () => {
+	const dispatch = jest.fn();
+	listPublicImagesMock.mockResolvedValue([
+		{
+			id: 'image-1',
+			ownerId: 'owner-1',
+			title: 'Backend image',
+			description: 'Loaded from the provider-agnostic API',
+			imageUrl: 'https://cdn.test/image-1.jpg',
+			thumbnailUrl: 'https://cdn.test/image-1-thumb.jpg',
+			isPublic: true,
+			createdAt: '2026-06-22T12:00:00.000Z',
+		},
+	]);
+
+	await loadImages()(dispatch);
+
+	expect(listPublicImagesMock).toHaveBeenCalledWith();
+	expect(getPublicImagesMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenNthCalledWith(1, {
+		type: ActionType.SET_ASYNC_STATUS,
+		feature: 'publicGallery',
+		status: 'loading',
+		error: null,
+	});
+	expect(dispatch).toHaveBeenNthCalledWith(2, {
+		type: ActionType.LOAD_IMAGES,
+		imgList: [
+			{
+				imgId: 'image-1',
+				imgArchived: false,
+				imgDescription: 'Loaded from the provider-agnostic API',
+				imgLikes: 0,
+				imgName: 'Backend image',
+				imgPrivate: false,
+				imgSrc: 'https://cdn.test/image-1.jpg',
+				imgUploadDate: Date.parse('2026-06-22T12:00:00.000Z'),
+				imgUserOwner: 'owner-1',
+			},
+		],
+	});
+	expect(dispatch).toHaveBeenNthCalledWith(3, {
+		type: ActionType.SET_ASYNC_STATUS,
+		feature: 'publicGallery',
+		status: 'succeeded',
+		error: null,
+	});
+});
+
+test('public gallery load path stores an error state when listPublicImages rejects', async () => {
+	const dispatch = jest.fn();
+	const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+	listPublicImagesMock.mockRejectedValue(new Error('API unavailable'));
+
+	try {
+		await loadImages()(dispatch);
+
+		expect(getPublicImagesMock).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.LOAD_IMAGES_ERROR,
+			error: 'Unable to load images: API unavailable',
+		});
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.SET_ASYNC_STATUS,
+			feature: 'publicGallery',
+			status: 'failed',
+			error: 'Unable to load images: API unavailable',
+		});
+	} finally {
+		consoleErrorSpy.mockRestore();
+	}
+});
+
+test('protected user gallery load path obtains a Firebase ID token and calls listMyImages', async () => {
+	const dispatch = jest.fn();
+	const getIdToken = jest.fn().mockResolvedValue('id-token-1');
+	mockCurrentUser = { getIdToken };
+	listMyImagesMock.mockResolvedValue([
+		{
+			id: 'user-image-1',
+			ownerId: 'owner-1',
+			title: 'My backend image',
+			description: 'Private gallery image',
+			imageUrl: 'https://cdn.test/user-image-1.jpg',
+			thumbnailUrl: 'https://cdn.test/user-image-1-thumb.jpg',
+			isPublic: false,
+			createdAt: '2026-06-23T12:00:00.000Z',
+		},
+	]);
+
+	await loadUserImages(true)(dispatch);
+
+	expect(getIdToken).toHaveBeenCalledWith();
+	expect(listMyImagesMock).toHaveBeenCalledWith({ idToken: 'id-token-1', archived: true });
+	expect(getUserImagesMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenNthCalledWith(1, {
+		type: ActionType.SET_ASYNC_STATUS,
+		feature: 'userGallery',
+		status: 'loading',
+		error: null,
+	});
+	expect(dispatch).toHaveBeenNthCalledWith(2, {
+		type: ActionType.LOAD_USER_IMAGES,
+		imgUserList: [
+			{
+				imgId: 'user-image-1',
+				imgArchived: false,
+				imgDescription: 'Private gallery image',
+				imgLikes: 0,
+				imgName: 'My backend image',
+				imgPrivate: true,
+				imgSrc: 'https://cdn.test/user-image-1.jpg',
+				imgUploadDate: Date.parse('2026-06-23T12:00:00.000Z'),
+				imgUserOwner: 'owner-1',
+			},
+		],
+	});
+	expect(dispatch).toHaveBeenNthCalledWith(3, {
+		type: ActionType.SET_ASYNC_STATUS,
+		feature: 'userGallery',
+		status: 'succeeded',
+		error: null,
+	});
+});
+
+test('normal protected user gallery load path calls listMyImages without archived flag', async () => {
+	const dispatch = jest.fn();
+	const getIdToken = jest.fn().mockResolvedValue('id-token-1');
+	mockCurrentUser = { getIdToken };
+	listMyImagesMock.mockResolvedValue([]);
+
+	await loadUserImages()(dispatch);
+
+	expect(getIdToken).toHaveBeenCalledWith();
+	expect(listMyImagesMock).toHaveBeenCalledWith({ idToken: 'id-token-1' });
+	expect(getUserImagesMock).not.toHaveBeenCalled();
+});
+
+test('protected user gallery load path stores empty state when backend returns no images', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('id-token-1') };
+	listMyImagesMock.mockResolvedValue([]);
+
+	await loadUserImages()(dispatch);
+
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.LOAD_USER_IMAGES,
+		imgUserList: [],
+	});
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.SET_ASYNC_STATUS,
+		feature: 'userGallery',
+		status: 'succeeded',
+		error: null,
+	});
+});
+
+test('protected user gallery load path stores an error state when listMyImages rejects', async () => {
+	const dispatch = jest.fn();
+	const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('id-token-1') };
+	listMyImagesMock.mockRejectedValue(new Error('API unavailable'));
+
+	try {
+		await loadUserImages()(dispatch);
+
+		expect(getUserImagesMock).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.LOAD_IMAGES_ERROR,
+			error: 'Unable to load images: API unavailable',
+		});
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.SET_ASYNC_STATUS,
+			feature: 'userGallery',
+			status: 'failed',
+			error: 'Unable to load images: API unavailable',
+		});
+	} finally {
+		consoleErrorSpy.mockRestore();
+	}
+});
+
+test('protected user gallery load path fails when Firebase current user is missing', async () => {
+	const dispatch = jest.fn();
+	const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+	mockCurrentUser = null;
+
+	try {
+		await loadUserImages()(dispatch);
+
+		expect(listMyImagesMock).not.toHaveBeenCalled();
+		expect(getUserImagesMock).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.SET_ASYNC_STATUS,
+			feature: 'userGallery',
+			status: 'failed',
+			error: 'User is not logged in.',
+		});
+	} finally {
+		consoleErrorSpy.mockRestore();
+	}
+});
+
+test('protected user gallery load path stores an error state when ID token retrieval fails', async () => {
+	const dispatch = jest.fn();
+	const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+	mockCurrentUser = { getIdToken: jest.fn().mockRejectedValue(new Error('Token unavailable')) };
+
+	try {
+		await loadUserImages()(dispatch);
+
+		expect(listMyImagesMock).not.toHaveBeenCalled();
+		expect(getUserImagesMock).not.toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.LOAD_IMAGES_ERROR,
+			error: 'Unable to load images: Token unavailable',
+		});
+		expect(dispatch).toHaveBeenCalledWith({
+			type: ActionType.SET_ASYNC_STATUS,
+			feature: 'userGallery',
+			status: 'failed',
+			error: 'Unable to load images: Token unavailable',
+		});
+	} finally {
+		consoleErrorSpy.mockRestore();
+	}
+});
+
+test('hide flow obtains a Firebase ID token and calls canonical visibility API', async () => {
+	const dispatch = jest.fn();
+	const getIdToken = jest.fn().mockResolvedValue('visibility-token-1');
+	const image = {
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	};
+	mockCurrentUser = { getIdToken };
+	updateImageVisibilityMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+
+	await togglePrivateImage(image, false)(dispatch);
+
+	expect(getIdToken).toHaveBeenCalledWith();
+	expect(updateImageVisibilityMock).toHaveBeenCalledWith({
+		imageId: 'backend-image-1',
+		idToken: 'visibility-token-1',
+		isPublic: false,
+	});
+	expect(updateImageVisibilityMock.mock.calls[0][0]).not.toMatchObject({
+		imageId: 'https://cdn.test/backend-image-1.jpg',
+	});
+	expect(updateImageVisibilityMock.mock.calls[0][0]).not.toHaveProperty('uid');
+	expect(setImagePrivacyMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.TOGGLE_PRIVATE_IMAGE,
+		imgId: 'backend-image-1',
+		imgPrivate: true,
+	});
+});
+
+test('show flow obtains a Firebase ID token and calls canonical visibility API', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('visibility-token-1') };
+	updateImageVisibilityMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: true,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+
+	await togglePrivateImage({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: true,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	}, true)(dispatch);
+
+	expect(updateImageVisibilityMock).toHaveBeenCalledWith({
+		imageId: 'backend-image-1',
+		idToken: 'visibility-token-1',
+		isPublic: true,
+	});
+	expect(setImagePrivacyMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.TOGGLE_PRIVATE_IMAGE,
+		imgId: 'backend-image-1',
+		imgPrivate: false,
+	});
+});
+
+test('archive flow obtains a Firebase ID token and calls canonical archive API', async () => {
+	const dispatch = jest.fn();
+	const getIdToken = jest.fn().mockResolvedValue('archive-token-1');
+	mockCurrentUser = { getIdToken };
+	archiveImageByIdMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		isArchived: true,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+
+	await archiveImageAction({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	}, false, true)(dispatch);
+
+	expect(getIdToken).toHaveBeenCalledWith();
+	expect(archiveImageByIdMock).toHaveBeenCalledWith({
+		imageId: 'backend-image-1',
+		idToken: 'archive-token-1',
+	});
+	expect(archiveImageByIdMock.mock.calls[0][0]).not.toHaveProperty('uid');
+	expect(archiveImageByIdMock.mock.calls[0][0]).not.toMatchObject({
+		imageId: 'https://cdn.test/backend-image-1.jpg',
+	});
+	expect(legacyArchiveImageMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.ARCHIVE_IMAGE,
+		imgId: 'backend-image-1',
+		imgArchived: true,
+		removeFromList: true,
+	});
+});
+
+test('unarchive flow obtains a Firebase ID token and calls canonical unarchive API', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('archive-token-1') };
+	unarchiveImageByIdMock.mockResolvedValue({
+		id: 'backend-image-1',
+		imageUrl: 'https://cdn.test/backend-image-1.jpg',
+		isPublic: false,
+		isArchived: false,
+		createdAt: '2026-06-23T12:00:00.000Z',
+	});
+
+	await archiveImageAction({
+		imgId: 'backend-image-1',
+		imgArchived: true,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	}, true)(dispatch);
+
+	expect(unarchiveImageByIdMock).toHaveBeenCalledWith({
+		imageId: 'backend-image-1',
+		idToken: 'archive-token-1',
+	});
+	expect(legacyArchiveImageMock).not.toHaveBeenCalled();
+	expect(dispatch).toHaveBeenCalledWith({
+		type: ActionType.ARCHIVE_IMAGE,
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		removeFromList: undefined,
+	});
+});
+
+test('metadata update flows fail before API call when image id is missing', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('token-1') };
+	const image = {
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	};
+
+	await expect(togglePrivateImage(image, false)(dispatch)).rejects.toThrow('Missing image id. Cannot update visibility for image.');
+	await expect(archiveImageAction(image, false)(dispatch)).rejects.toThrow('Missing image id. Cannot archive image.');
+
+	expect(updateImageVisibilityMock).not.toHaveBeenCalled();
+	expect(archiveImageByIdMock).not.toHaveBeenCalled();
+	expect(unarchiveImageByIdMock).not.toHaveBeenCalled();
+});
+
+test('metadata update flows fail when Firebase current user is missing', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = null;
+	const image = {
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	};
+
+	await expect(togglePrivateImage(image, false)(dispatch)).rejects.toThrow('User is not logged in.');
+	await expect(archiveImageAction(image, false)(dispatch)).rejects.toThrow('User is not logged in.');
+
+	expect(updateImageVisibilityMock).not.toHaveBeenCalled();
+	expect(archiveImageByIdMock).not.toHaveBeenCalled();
+});
+
+test('metadata update flows surface token retrieval and API failures', async () => {
+	const dispatch = jest.fn();
+	const image = {
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	};
+
+	mockCurrentUser = { getIdToken: jest.fn().mockRejectedValue(new Error('Token unavailable')) };
+	await expect(togglePrivateImage(image, false)(dispatch)).rejects.toThrow('Token unavailable');
+
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('archive-token-1') };
+	archiveImageByIdMock.mockRejectedValue(new Error('Archive failed'));
+	await expect(archiveImageAction(image, false)(dispatch)).rejects.toThrow('Archive failed');
+});
+
+test('delete flow obtains a Firebase ID token and calls canonical deleteImage input', async () => {
+	const dispatch = jest.fn();
+	const getIdToken = jest.fn().mockResolvedValue('delete-token-1');
+	const image = {
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: 'Delete me',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: Date.parse('2026-06-23T12:00:00.000Z'),
+		imgUserOwner: 'user-123',
+	};
+	mockCurrentUser = { getIdToken };
+	deleteImageMock.mockResolvedValue({ imageId: 'backend-image-1', deleted: true });
+
+	await deleteImage(image)(dispatch);
+
+	expect(getIdToken).toHaveBeenCalledWith();
+	expect(deleteImageMock).toHaveBeenCalledWith({
+		imageId: 'backend-image-1',
+		idToken: 'delete-token-1',
+	});
+	expect(deleteImageMock.mock.calls[0][0]).not.toBe(image);
+	expect(deleteImageMock.mock.calls[0][0]).not.toMatchObject({
+		imageId: 'https://cdn.test/backend-image-1.jpg',
+	});
+	expect(deleteImageMock.mock.calls[0][0]).not.toHaveProperty('uid');
+	expect(dispatch).not.toHaveBeenCalled();
+});
+
+test('delete flow handles deleted false without crashing', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('delete-token-1') };
+	deleteImageMock.mockResolvedValue({ imageId: 'backend-image-1', deleted: false });
+
+	await expect(deleteImage({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	})(dispatch)).resolves.toBeUndefined();
+});
+
+test('delete flow fails before API call when image id is missing', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('delete-token-1') };
+
+	await expect(deleteImage({
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	})(dispatch)).rejects.toThrow('Missing image id. Cannot delete image.');
+
+	expect(deleteImageMock).not.toHaveBeenCalled();
+});
+
+test('delete flow fails when Firebase current user is missing', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = null;
+
+	await expect(deleteImage({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	})(dispatch)).rejects.toThrow('User is not logged in.');
+
+	expect(deleteImageMock).not.toHaveBeenCalled();
+});
+
+test('delete flow surfaces ID token retrieval failures', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockRejectedValue(new Error('Token unavailable')) };
+
+	await expect(deleteImage({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	})(dispatch)).rejects.toThrow('Token unavailable');
+
+	expect(deleteImageMock).not.toHaveBeenCalled();
+});
+
+test('delete flow surfaces API delete failures', async () => {
+	const dispatch = jest.fn();
+	mockCurrentUser = { getIdToken: jest.fn().mockResolvedValue('delete-token-1') };
+	deleteImageMock.mockRejectedValue(new Error('Delete failed'));
+
+	await expect(deleteImage({
+		imgId: 'backend-image-1',
+		imgArchived: false,
+		imgDescription: '',
+		imgLikes: 0,
+		imgName: 'legacy-file-name.jpg',
+		imgPrivate: false,
+		imgSrc: 'https://cdn.test/backend-image-1.jpg',
+		imgUploadDate: 0,
+		imgUserOwner: 'user-123',
+	})(dispatch)).rejects.toThrow('Delete failed');
+});
+
+export {};

--- a/src/state/actionCreators/index.tsx
+++ b/src/state/actionCreators/index.tsx
@@ -4,7 +4,36 @@ import { Action, AsyncFeature, AsyncStatus, SetAsyncStatusAction } from '../acti
 import * as Api from 'api';
 import { ImageInterface } from 'type';
 import { logger } from 'utils/logger';
-import { RootState } from '../reducers';
+import { auth } from 'firebase.configuration';
+
+const mapPhotogramImageToImageInterface = (image: Api.PhotogramImage): ImageInterface => ({
+	imgId: image.id,
+	imgArchived: Boolean(image.isArchived),
+	imgDescription: image.description ?? '',
+	imgLikes: 0,
+	imgName: image.title ?? image.id,
+	imgPrivate: !image.isPublic,
+	imgSrc: image.imageUrl,
+	imgUploadDate: Date.parse(image.createdAt) || 0,
+	imgUserOwner: image.ownerId ?? '',
+});
+
+const getCurrentUserIdToken = async () => {
+	const currentUser = auth.currentUser;
+	if (!currentUser) {
+		throw new Error('User is not logged in.');
+	}
+
+	return currentUser.getIdToken();
+};
+
+const getImageId = (image: ImageInterface, action: string) => {
+	if (!image.imgId?.trim()) {
+		throw new Error(`Missing image id. Cannot ${action} image.`);
+	}
+
+	return image.imgId;
+};
 
 export const setAsyncStatus = (
 	feature: AsyncFeature,
@@ -22,10 +51,10 @@ export const loadImages = () => {
 		dispatch(setAsyncStatus('publicGallery', 'loading'));
 
 		try {
-			const results = await Api.getPublicImages();
+			const results = await Api.listPublicImages();
 			dispatch({
 				type: ActionType.LOAD_IMAGES,
-				imgList: results,
+				imgList: results.map(mapPhotogramImageToImageInterface),
 			});
 			dispatch(setAsyncStatus('publicGallery', 'succeeded'));
 		} catch (err) {
@@ -38,10 +67,11 @@ export const loadImages = () => {
 };
 
 export const loadUserImages = (showArchived?: boolean) => {
-	return async (dispatch: Dispatch<Action>, getState: () => RootState) => {
+	return async (dispatch: Dispatch<Action>) => {
 		dispatch(setAsyncStatus('userGallery', 'loading'));
-		const { uid } = getState().auth;
-		if (!uid) {
+
+		const currentUser = auth.currentUser;
+		if (!currentUser) {
 			const error = 'User is not logged in.';
 			logger.error(error);
 			dispatch(setAsyncStatus('userGallery', 'failed', error));
@@ -49,10 +79,11 @@ export const loadUserImages = (showArchived?: boolean) => {
 		}
 
 		try {
-			const results = await Api.getUserImages(uid, showArchived);
+			const idToken = await currentUser.getIdToken();
+			const results = await Api.listMyImages(showArchived ? { idToken, archived: true } : { idToken });
 			dispatch({
 				type: ActionType.LOAD_USER_IMAGES,
-				imgUserList: results,
+				imgUserList: results.map(mapPhotogramImageToImageInterface),
 			});
 			dispatch(setAsyncStatus('userGallery', 'succeeded'));
 		} catch (err) {
@@ -75,10 +106,18 @@ export const clearImages = () => {
 
 export const archiveImage = (image: ImageInterface, imgArchived: boolean, removeFromList?: boolean) => {
 	return async (dispatch: Dispatch<Action>) => {
-		await Api.archiveImage(image, imgArchived);
+		const imageId = getImageId(image, 'archive');
+		const idToken = await getCurrentUserIdToken();
+
+		if (imgArchived) {
+			await Api.unarchiveImageById({ imageId, idToken });
+		} else {
+			await Api.archiveImageById({ imageId, idToken });
+		}
+
 		dispatch({
 			type: ActionType.ARCHIVE_IMAGE,
-			imgId: image.imgId,
+			imgId: imageId,
 			imgArchived: !imgArchived,
 			removeFromList,
 		});
@@ -87,11 +126,30 @@ export const archiveImage = (image: ImageInterface, imgArchived: boolean, remove
 
 export const togglePrivateImage = (image: ImageInterface, isPrivate: boolean) => {
 	return async (dispatch: Dispatch<Action>) => {
-		await Api.setImagePrivacy(image, isPrivate);
+		const imageId = getImageId(image, 'update visibility for');
+		const idToken = await getCurrentUserIdToken();
+
+		await Api.updateImageVisibility({
+			imageId,
+			idToken,
+			isPublic: isPrivate,
+		});
+
 		dispatch({
 			type: ActionType.TOGGLE_PRIVATE_IMAGE,
-			imgId: image.imgId,
+			imgId: imageId,
 			imgPrivate: !isPrivate,
+		});
+	};
+};
+
+export const deleteImage = (image: ImageInterface) => {
+	return async (_dispatch: Dispatch<Action>) => {
+		const imageId = getImageId(image, 'delete');
+		const idToken = await getCurrentUserIdToken();
+		await Api.deleteImage({
+			imageId,
+			idToken,
 		});
 	};
 };


### PR DESCRIPTION
## Summary

This PR migrates the main Photogram frontend flows to the provider-backed backend image API.

The frontend now treats the backend as the source of truth for gallery reads, uploads, deletes, visibility changes, and archive actions. Firebase Auth remains in place for login and ID token retrieval, but migrated image flows no longer depend on direct Firestore/Firebase Storage reads or writes.

## Behavior changes

Migrated frontend flows:

```text
/                     -> Api.listPublicImages()
/mygallery            -> Api.listMyImages({ idToken })
/mygallery archived   -> Api.listMyImages({ idToken, archived: true })
/upload               -> Api.uploadImage({ file, idToken, description, isPublic })
delete                -> Api.deleteImage({ imageId, idToken })
hide/show             -> Api.updateImageVisibility({ imageId, idToken, isPublic })
archive               -> Api.archiveImageById({ imageId, idToken })
unarchive             -> Api.unarchiveImageById({ imageId, idToken })
````

The frontend now depends on:

```env
REACT_APP_API_URL=http://localhost:3003
```

It does not use backend provider env vars such as:

```text
AUTH_PROVIDER
DATABASE_PROVIDER
STORAGE_PROVIDER
SQLITE_PATH
LOCAL_STORAGE_ROOT
```

## API client changes

Added provider-agnostic image API client support for:

```ts
listPublicImages()
listMyImages({ idToken })
uploadImage({ file, idToken, description, isPublic })
deleteImage({ imageId, idToken })
updateImageVisibility({ imageId, idToken, isPublic })
archiveImageById({ imageId, idToken })
unarchiveImageById({ imageId, idToken })
```

Also added/updated frontend DTOs for:

```ts
PhotogramImage
PaginationOptions
AuthenticatedImageRequest
UploadImageInput
DeleteImageInput
UpdateImageVisibilityInput
ArchiveImageInput
DeleteImageResult
ApiError
```

Legacy exports remain for compatibility where still needed.

## Auth and ownership model

* Firebase Auth remains for login/bootstrap.
* Authenticated backend calls use `auth.currentUser.getIdToken()`.
* ID tokens are not stored in Redux, localStorage, or sessionStorage.
* The frontend does not send UID as the ownership source of truth.
* The backend infers ownership from the Firebase ID token.
* Delete/archive/hide/show use backend image IDs, not URLs, filenames, or storage paths.

## UI behavior

* Public gallery loads from `GET /images/public` and does not require auth.
* User gallery loads from `GET /images/me` with an ID token.
* Archived view loads from `GET /images/me?archived=true`.
* Upload sends multipart form data to `POST /images` with field name `image`.
* Upload success uses backend `image.imageUrl`.
* Delete calls `DELETE /images/:imageId`.
* Hide/show calls `PATCH /images/:imageId/visibility`.
* Archive/unarchive calls `POST /images/:imageId/archive` and `POST /images/:imageId/unarchive`.

## Backend/API contract impact

This frontend expects the backend to expose:

```text
GET    /images/public
GET    /images/me
POST   /images
DELETE /images/:imageId
PATCH  /images/:imageId/visibility
POST   /images/:imageId/archive
POST   /images/:imageId/unarchive
```

Expected backend response shape for image DTOs includes:

```ts
{
  id: string;
  imageUrl: string;
  thumbnailUrl?: string;
  isPublic: boolean;
  isArchived?: boolean;
  archivedAt?: string;
  createdAt: string;
}
```

The frontend intentionally does not consume provider-specific fields such as `storageKey` or `thumbnailKey`.

## Tests

Automated checks passed:

```bash
yarn test --watchAll=false
yarn build
```

Focused test commands passed:

```bash
yarn test --watchAll=false --runTestsByPath src/api/images.test.ts
yarn test --watchAll=false --runTestsByPath src/state/actionCreators/index.test.ts
yarn test --watchAll=false --runTestsByPath src/components/App/App.test.tsx
yarn test --watchAll=false --runTestsByPath src/components/Gallery/UploadImage/UploadImage.test.tsx
yarn test --watchAll=false --runTestsByPath src/components/Gallery/ShowGallery/ShowGallery.test.tsx
```

Result:

```text
5 suites, 74 tests passed
```

Non-blocking warnings remain:

```text
Yarn cache permission fallback
Node deprecation warnings
Browserslist age warning
React Router future-flag test warnings
```

## Manual validation

Run frontend with:

```env
REACT_APP_API_URL=http://localhost:3003
```

Then validate:

```text
1. Visit /
   Expect GET /images/public without Authorization.

2. Sign in.

3. Visit /mygallery
   Expect GET /images/me with Authorization: Bearer <firebase-id-token>.

4. Visit /upload and upload an image
   Expect POST /images with multipart field image.

5. Hide the image
   Expect PATCH /images/:imageId/visibility with { "isPublic": false }.
   Refresh / and confirm it disappears from public gallery.

6. Show the image
   Expect PATCH /images/:imageId/visibility with { "isPublic": true }.
   Refresh / and confirm it appears publicly again.

7. Archive the image
   Expect POST /images/:imageId/archive.
   Refresh /mygallery and confirm it disappears from normal view.

8. Open archived view
   Expect GET /images/me?archived=true.

9. Unarchive the image
   Expect POST /images/:imageId/unarchive.

10. Delete the image
    Expect DELETE /images/:imageId.
    Refresh /mygallery and confirm it remains deleted.
```

## Notes

* Firestore/Firebase Storage compatibility exports remain where still needed.
* Migrated user-facing gallery/upload/delete/archive/visibility flows bypass Firestore/Firebase Storage paths.
* No `.env`, build output, `node_modules`, secrets, or local logs were committed.
